### PR TITLE
refactor(docs): Add build-time option embedding to docs

### DIFF
--- a/.opencode/skills/docs/SKILL.md
+++ b/.opencode/skills/docs/SKILL.md
@@ -20,46 +20,41 @@ Keep docs clear, accurate, and synced with repo. Goal: make system configs, user
 3. **Draft Content**:
    - Create or update Markdown files in `docs/src`
    - Use underscore filenames like `my_new_feature.md`
-   - For modules, give high-level overview and link to relevant code or external resources
-4. **Update Summary**: Make sure new files are added to `docs/src/SUMMARY.md` so book structure stays correct
-5. **Verify**: Check Nix code examples are valid and build commands are accurate
+   - For modules, provide a high-level overview and link to relevant code or external resources
+   - When documenting module options, prefer build-time generated option fragments via `{{#include}}` from `docs/src/generated/*.md` instead of hand-maintained option tables or client-side widgets
+   - Keep the prose focused on behavior, architecture, usage examples, and operational notes; let generated fragments provide the exhaustive option reference
+4. **Update Summary**: Make new files are added to `docs/src/SUMMARY.md` so book structure stays correct.
+5. **Verify**: Check that Nix code examples are valid and build commands are accurate
 
 ## Guardrails
-- **Location**: Documentation must live under `docs/src`
-- **Option Documentation**: Do not document every single module option. Use options search unless config is complex or needs special explanation
-- **Scope**: Do not document user-only modules like anything under `home/racci/features/cli/`. Focus on shared modules and system-wide configs
-- **Filenames**: Always use underscores (`_`), not hyphens (`-`)
-- **Style**: Keep explanations concise. Focus on *why* config exists, not only *what* code does
+- **Location**: Documentation must live under `docs/src`.
+- **Option Documentation**: Avoid hand-documenting every single module option. For documented modules, prefer build-time generated option fragments included with `{{#include}}`; use prose only for special explanation, caveats, or examples.
+- **Scope**: Do not document user-only modules (e.g., anything under `home/racci/features/cli/`). Focus on shared modules and system-wide configurations.
+- **Filenames**: Always use underscores (`_`) instead of hyphens (`-`) for documentation filenames.
+- **Style**: Keep explanations concise. Focus on *why* something is configured a certain way rather than just *what* the code does.
 
 ## Examples
 
 ### Adding new module doc
 1. Create `docs/src/modules/my_service.md`:
-````markdown
-# My Service
+   - a short overview,
+   - the module entry point,
+   - usage examples,
+   - operational notes if needed,
+   - and an option reference section that includes a generated fragment.
 
-Overview of what service does and why it is included in config.
+2. Generate option fragment at build time from module's `options.json`, include it in page with `{{#include}}`, for example `docs/src/generated/my-service-options.md`.
 
-## Usage
-Link to implementation: [modules/nixos/services/my-service.nix](../../modules/nixos/services/my-service.nix)
+3. Update `docs/src/SUMMARY.md`:
+   - register new page in book structure,
+   - ensure generated-option workflow changes are reflected in docs build if needed.
 
-```nix
-{
-  services.myService.enable = true;
-}
-```
-
-2. Update `docs/src/SUMMARY.md`:
-
-```markdown
-# Summary
-
-- [Introduction](README.md)
-- [Modules](modules/overview.md)
-  - [My Service](modules/my_service.md)
-````
+4. Prefer this pattern for future module docs:
+   - prose in page,
+   - exhaustive option reference in a generated include,
+   - no manually maintained option tables unless there is a very specific reason.
 
 ### Updating host documentation
-If host config changes in significant way:
+If host config changes significant:
 - Update relevant host file in `docs/src/hosts/`
 - Make sure hardware-specific details or special manual steps are documented

--- a/.opencode/skills/docs/SKILL.md
+++ b/.opencode/skills/docs/SKILL.md
@@ -55,6 +55,6 @@ Keep docs clear, accurate, and synced with repo. Goal: make system configs, user
    - no manually maintained option tables unless there is a very specific reason.
 
 ### Updating host documentation
-If host config changes significant:
+If host config changes significantly:
 - Update relevant host file in `docs/src/hosts/`
 - Make sure hardware-specific details or special manual steps are documented

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -5,11 +5,20 @@ src = "src"
 
 [output.html]
 site-url = "/nix-config/"
-git-repository-url = "https://github.com/DaRacci/nix-config"
-edit-url-template = "https://github.com/DaRacci/nix-config/edit/master/docs/{path}"
+git-repository-url = "https://codeberg.org/Racci/nix-config"
+edit-url-template = "https://codeberg.org/Racci/nix-config/src/docs/{path}"
 no-section-label = true
-# Ensure static file (css, js) have a unique filename, to avoid outdated cache.
+# Ensure static file assets have unique filename, to avoid outdated cache.
 hash-files = true
 
 [output.html.fold]
 enable = true
+
+[preprocessor.rewrite-links]
+command = "mdbook-rewrite-links"
+git-branch = "master"
+renderers = ["html"]
+
+
+[preprocessor.gitinfo]
+branch = "master"

--- a/docs/default.nix
+++ b/docs/default.nix
@@ -6,6 +6,236 @@
   lib,
   ...
 }:
+let
+  inherit (inputs.search.packages.${system}) mkOptionsJSON;
+  inherit (lib)
+    any
+    hasInfix
+    filterAttrs
+    mapAttrsToList
+    removePrefix
+    hasSuffix
+    concatLists
+    ;
+
+  # Build minimal module evaluations suitable for options documentation.
+  # Keep specialArgs aligned with normal module loading so recursive scans can
+  # evaluate modules that expect repository-level args.
+  mkFlakeOptionsJSON =
+    modules:
+    mkOptionsJSON {
+      inherit modules;
+      specialArgs = {
+        inherit inputs lib self;
+      };
+    };
+
+  mkNixosOptionsJSON =
+    modules:
+    mkOptionsJSON {
+      inherit modules;
+      specialArgs = {
+        inherit inputs lib self;
+        hostDirectory = "${self}/hosts";
+        importExternals = false;
+        users = [ ];
+      };
+    };
+
+  mkHomeManagerOptionsJSON =
+
+    modules:
+    mkOptionsJSON {
+      inherit modules;
+      specialArgs = {
+        inherit inputs lib self;
+        hostDirectory = "${self}/hosts";
+        importExternals = false;
+      };
+    };
+
+  mkFlakeModuleOptions =
+    path:
+    mkFlakeOptionsJSON [
+      "${self}/modules/flake/default.nix"
+      path
+    ];
+
+  mkNixosModuleOptions =
+    path:
+    mkNixosOptionsJSON [
+
+      "${self}/modules/nixos/default.nix"
+      path
+      {
+        _module.args = {
+          inherit self inputs pkgs;
+        };
+      }
+    ];
+
+  mkHomeManagerModuleOptions =
+    path:
+    mkHomeManagerOptionsJSON [
+      "${self}/modules/home-manager/purpose/default.nix"
+      path
+      {
+        _module.args = {
+          inherit self inputs pkgs;
+          outputs = self.outputs;
+          osConfig = null;
+        };
+
+        _module.check = false;
+      }
+    ];
+
+  flakeAggregateOptionsJSON = mkFlakeOptionsJSON [ "${self}/modules/flake/default.nix" ];
+
+  nixosAggregateOptionsJSON = mkNixosOptionsJSON [
+
+    "${self}/modules/nixos/default.nix"
+    {
+      _module.args = {
+        inherit self inputs pkgs;
+      };
+    }
+  ];
+
+  homeManagerAggregateOptionsJSON = mkHomeManagerOptionsJSON [
+    "${self}/modules/home-manager/purpose/default.nix"
+    {
+      _module.args = {
+        inherit self inputs pkgs;
+        outputs = self.outputs;
+        osConfig = null;
+      };
+
+      _module.check = false;
+    }
+  ];
+
+  discoverModules =
+    category: moduleDir: mkFn: aggregateJSON:
+
+    let
+      fileLooksLikeModule =
+        path:
+        let
+          content = builtins.readFile path;
+          hasModuleBody = any (needle: hasInfix needle content) [
+            "options."
+            "options ="
+            "config ="
+            "imports ="
+          ];
+          isModuleFactory = any (needle: hasInfix needle content) [
+            "imports ? [ ]"
+            "options ? { }"
+            "extraConfig ? { }"
+          ];
+
+        in
+        hasModuleBody && !isModuleFactory;
+
+      findModuleFilesRec =
+        dir: relDir:
+        let
+          entries = builtins.readDir dir;
+          files = filterAttrs (
+            name: type: hasSuffix ".nix" name && type == "regular" && fileLooksLikeModule "${dir}/${name}"
+          ) entries;
+          subdirs = filterAttrs (_: type: type == "directory") entries;
+          fileResults = mapAttrsToList (
+            name: _:
+            let
+              relPath = removePrefix "/" "${relDir}/${name}";
+            in
+            {
+              inherit relPath;
+              fullPath = "${dir}/${name}";
+              isCurriedHelper =
+                let
+                  content = builtins.readFile "${dir}/${name}";
+                in
+                hasInfix "}:
+{" content || hasInfix "_:
+{" content;
+              isDefault = name == "default.nix";
+            }
+
+          ) files;
+          subResults = concatLists (
+            mapAttrsToList (subdir: _: findModuleFilesRec "${dir}/${subdir}" "${relDir}/${subdir}") subdirs
+          );
+        in
+        fileResults ++ subResults;
+
+      pathToPrefix =
+        relPath:
+        let
+          withoutDefault =
+            if relPath == "default.nix" then
+              ""
+            else if lib.hasSuffix "/default.nix" relPath then
+              lib.removeSuffix "/default.nix" relPath
+            else
+              lib.removeSuffix ".nix" relPath;
+        in
+        builtins.replaceStrings [ "/" ] [ "." ] withoutDefault;
+
+      normalizePrefix =
+        prefix: prefix |> lib.splitString "." |> map lib.strings.toCamelCase |> lib.concatStringsSep ".";
+
+      prefixToOutputName = prefix: builtins.replaceStrings [ "." ] [ "-" ] prefix;
+
+      moduleToEntry =
+        module:
+        let
+          discoveredPrefix = pathToPrefix module.relPath;
+          prefix = prefixOverrides.${discoveredPrefix} or (normalizePrefix discoveredPrefix);
+          outputName = prefixToOutputName discoveredPrefix;
+          json = if module.isDefault || module.isCurriedHelper then aggregateJSON else mkFn module.fullPath;
+
+        in
+        {
+          name = discoveredPrefix;
+          value = {
+            path = module.fullPath;
+            inherit
+              json
+              prefix
+              outputName
+              category
+              ;
+          };
+        };
+    in
+    builtins.listToAttrs (map moduleToEntry (findModuleFilesRec moduleDir ""));
+
+  discoverFlakeModules =
+    discoverModules "flake" "${self}/modules/flake" mkFlakeModuleOptions
+      flakeAggregateOptionsJSON;
+  discoverNixosModules =
+
+    discoverModules "nixos" "${self}/modules/nixos" mkNixosModuleOptions nixosAggregateOptionsJSON;
+  discoverHomeManagerModules =
+    discoverModules "home-manager" "${self}/modules/home-manager" mkHomeManagerModuleOptions
+      homeManagerAggregateOptionsJSON;
+
+  prefixOverrides = {
+    "services.woodpecker-nix" = "services.woodpeckerNix";
+  };
+
+  flakeModules = discoverFlakeModules;
+  nixosModules = discoverNixosModules;
+  homeManagerModules = discoverHomeManagerModules;
+
+  allModules = flakeModules // nixosModules // homeManagerModules;
+
+  moduleOptionsJSON = lib.mapAttrs (_name: module: module.json) allModules;
+
+in
 rec {
   search = pkgs.callPackage ./search.nix {
     inherit
@@ -17,6 +247,8 @@ rec {
     lib = pkgs.lib;
   };
 
+  inherit moduleOptionsJSON allModules;
+
   docs = pkgs.callPackage ./site.nix {
     inherit
       self
@@ -24,6 +256,12 @@ rec {
       pkgs
       lib
       search
+      moduleOptionsJSON
+      allModules
+
+      mkNixosModuleOptions
+      mkHomeManagerModuleOptions
+      discoverModules
       ;
   };
 

--- a/docs/preprocessor/gen-options-md.py
+++ b/docs/preprocessor/gen-options-md.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""
+Convert a NixOS options.json to a Markdown fragment suitable for {{#include}}
+in mdbook.  Each option gets its own level-4 heading plus a two-column
+metadata table, followed by its description and a source declaration line.
+
+Usage: gen-options-md.py <options.json> <prefix> <output.md>
+"""
+
+import json
+import sys
+from pathlib import Path
+
+
+def render_value(val):
+    """Collapse a NixOS literalExpression / literalMD / plain value to a string."""
+    if val is None:
+        return None
+    if isinstance(val, dict):
+        val_type = val.get("_type", "")
+        if val_type in ("literalExpression", "literalMD"):
+            return val.get("text", "")
+        return json.dumps(val)
+    if isinstance(val, bool):
+        return "true" if val else "false"
+    if isinstance(val, (list, tuple)):
+        return json.dumps(val)
+    return str(val)
+
+
+def escape_cell(s):
+    """Escape pipe characters and collapse newlines so table cells stay intact."""
+    return s.replace("|", "\\|").replace("\n", " ").strip()
+
+
+def candidate_prefixes(prefix, output_path):
+    """Return likely option prefixes for user input and output filename."""
+    candidates = []
+
+    def add(value):
+        if value and value not in candidates:
+            candidates.append(value)
+
+    def add_variants(value):
+        add(value)
+        add(value.replace("-", "."))
+
+        parts = value.split("-")
+        for i in range(1, len(parts)):
+            add(".".join(parts[:i]) + "-" + "-".join(parts[i:]))
+
+    add_variants(prefix)
+
+    stem = Path(output_path).stem
+    if stem.endswith("-options"):
+        stem = stem[: -len("-options")]
+    add_variants(stem)
+
+    return candidates
+
+
+def main():
+    options_path, prefix, output_path = sys.argv[1], sys.argv[2], sys.argv[3]
+
+    with open(options_path, encoding="utf-8") as f:
+        options = json.load(f)
+
+    prefixes = candidate_prefixes(prefix, output_path)
+
+    # Filter to requested prefix and drop internal module-system keys.
+    items = sorted(
+        [
+            (k, v)
+            for k, v in options.items()
+            if not k.startswith("_")
+            and any(k == p or k.startswith(p + ".") for p in prefixes)
+        ],
+        key=lambda x: x[0],
+    )
+
+    lines = []
+    for name, opt in items:
+        lines.append(f"#### `{name}`\n")
+
+        type_str = render_value(opt.get("type")) or "—"
+        default_val = render_value(opt.get("default"))
+        example_val = render_value(opt.get("example"))
+
+        lines.append("| | |")
+        lines.append("|---|---|")
+        lines.append(f"| **Type** | `{escape_cell(type_str)}` |")
+        if default_val is not None:
+            lines.append(f"| **Default** | `{escape_cell(default_val)}` |")
+        if example_val is not None:
+            lines.append(f"| **Example** | `{escape_cell(example_val)}` |")
+
+        lines.append("")
+
+        description = (render_value(opt.get("description")) or "").strip()
+        if description:
+            lines.append(description)
+            lines.append("")
+
+        # decls = opt.get("declarations", [])
+        # if decls:
+        #     links = ", ".join(f"`{d}`" for d in decls)
+        #     lines.append(f"*Declared in: {links}*\n")
+
+        lines.append("---\n")
+
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/preprocessor/rewrite-links.py
+++ b/docs/preprocessor/rewrite-links.py
@@ -74,7 +74,6 @@ def rewrite_target(
     target: str,
     chapter_path: str,
     docs_root: Path,
-    src_dir: str,
     base_url: str,
     branch: str,
 ) -> str | None:
@@ -108,7 +107,6 @@ def rewrite_text(
     text: str,
     chapter_path: str,
     docs_root: Path,
-    src_dir: str,
     base_url: str,
     branch: str,
 ) -> str:
@@ -121,7 +119,6 @@ def rewrite_text(
             target,
             chapter_path,
             docs_root,
-            src_dir,
             base_url,
             branch,
         )
@@ -137,7 +134,6 @@ def rewrite_text(
             target,
             chapter_path,
             docs_root,
-            src_dir,
             base_url,
             branch,
         )
@@ -153,9 +149,7 @@ def rewrite_text(
     return rewritten_text
 
 
-def process_item(
-    item: object, docs_root: Path, base_url: str, branch: str, src_dir: str
-) -> None:
+def process_item(item: object, docs_root: Path, base_url: str, branch: str) -> None:
     if not isinstance(item, dict):
         return
 
@@ -170,29 +164,26 @@ def process_item(
             chapter.get("content", ""),
             chapter_path,
             docs_root,
-            src_dir,
             base_url,
             branch,
         )
 
     for sub_item in chapter.get("sub_items", []):
-        process_item(sub_item, docs_root, base_url, branch, src_dir)
+        process_item(sub_item, docs_root, base_url, branch)
 
 
-def process_book(
-    book: dict, docs_root: Path, base_url: str, branch: str, src_dir: str
-) -> None:
+def process_book(book: dict, docs_root: Path, base_url: str, branch: str) -> None:
     items = book.get("items")
     if isinstance(items, list):
         for item in items:
-            process_item(item, docs_root, base_url, branch, src_dir)
+            process_item(item, docs_root, base_url, branch)
         return
 
     sections = book.get("sections")
     if isinstance(sections, list):
         LOGGER.debug("fallback to legacy book.sections traversal")
         for item in sections:
-            process_item(item, docs_root, base_url, branch, src_dir)
+            process_item(item, docs_root, base_url, branch)
 
 
 def run_tests() -> None:
@@ -220,7 +211,6 @@ def run_tests() -> None:
                 text,
                 self.chapter_path,
                 self.docs_root,
-                "src",
                 "https://codeberg.org/Racci/nix-config",
                 "master",
             )
@@ -234,7 +224,6 @@ def run_tests() -> None:
                 text,
                 self.chapter_path,
                 self.docs_root,
-                "src",
                 "https://codeberg.org/Racci/nix-config",
                 "master",
             )
@@ -259,7 +248,6 @@ def run_tests() -> None:
                 self.docs_root,
                 "https://codeberg.org/Racci/nix-config",
                 "master",
-                "src",
             )
 
             self.assertIn(
@@ -298,13 +286,12 @@ def main() -> None:
     docs_root = root / src_dir if (root / src_dir).is_dir() else book_root / src_dir
 
     LOGGER.debug(
-        "start rewrite with branch=%s src_dir=%s docs_root=%s",
+        "start rewrite with branch=%s docs_root=%s",
         branch,
-        src_dir,
         docs_root,
     )
 
-    process_book(book, docs_root, base_url, branch, src_dir)
+    process_book(book, docs_root, base_url, branch)
 
     sys.stdout.write(json.dumps(book))
 

--- a/docs/preprocessor/rewrite-links.py
+++ b/docs/preprocessor/rewrite-links.py
@@ -1,0 +1,316 @@
+import json
+import logging
+import re
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from urllib.parse import quote
+
+MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)\s]+)\)")
+HTML_LINK_RE = re.compile(
+    r'(<a\s+[^>]*href=")([^"]+)("[^>]*>)(.*?)(</a>)', re.IGNORECASE
+)
+
+REPO_ROOT_NAMES = {"modules", "flake", "lib", "hosts", "home", "pkgs", "overlays"}
+LOGGER = logging.getLogger("rewrite-links")
+
+
+def configure_logging() -> None:
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format="[rewrite-links] %(levelname)s: %(message)s",
+        stream=sys.stderr,
+    )
+
+
+def is_external_link(target: str) -> bool:
+    return re.match(
+        r"^[a-zA-Z][a-zA-Z0-9+.-]*:", target
+    ) is not None or target.startswith("#")
+
+
+def split_link_target(target: str) -> tuple[str, str]:
+    for separator in ("#", "?"):
+        if separator in target:
+            index = target.find(separator)
+            return target[:index], target[index:]
+    return target, ""
+
+
+def normalize_repo_relative_path(
+    chapter_path: str, link_path: str, docs_root: Path
+) -> Path | None:
+    chapter_fs_path = docs_root / chapter_path
+    candidate = (chapter_fs_path.parent / link_path).resolve(strict=False)
+    repo_root = docs_root.parent.parent
+
+    LOGGER.debug(
+        "resolve link chapter=%s link=%s chapter_fs=%s candidate=%s repo_root=%s",
+        chapter_path,
+        link_path,
+        chapter_fs_path,
+        candidate,
+        repo_root,
+    )
+
+    try:
+        relative = candidate.relative_to(repo_root)
+    except ValueError:
+        return None
+
+    if not relative.parts or relative.parts[0] not in REPO_ROOT_NAMES:
+        return None
+
+    return relative
+
+
+def build_codeberg_url(base_url: str, branch: str, repo_path: Path, suffix: str) -> str:
+    encoded_path = quote(repo_path.as_posix(), safe="/")
+    return f"{base_url.rstrip('/')}/src/branch/{quote(branch, safe='')}/{encoded_path}{suffix}"
+
+
+def rewrite_target(
+    target: str,
+    chapter_path: str,
+    docs_root: Path,
+    src_dir: str,
+    base_url: str,
+    branch: str,
+) -> str | None:
+    if is_external_link(target):
+        return None
+
+    link_path, suffix = split_link_target(target)
+    if not link_path:
+        return None
+
+    repo_path = normalize_repo_relative_path(chapter_path, link_path, docs_root)
+    if repo_path is None:
+        LOGGER.debug("skip unresolved link in %s: %s", chapter_path, target)
+        return None
+
+    if repo_path.suffix == "":
+        LOGGER.debug(
+            "skip non-file-like link in %s: %s -> %s",
+            chapter_path,
+            target,
+            repo_path,
+        )
+        return None
+
+    rewritten = build_codeberg_url(base_url, branch, repo_path, suffix)
+    LOGGER.debug("rewrite link in %s: %s -> %s", chapter_path, target, rewritten)
+    return rewritten
+
+
+def rewrite_text(
+    text: str,
+    chapter_path: str,
+    docs_root: Path,
+    src_dir: str,
+    base_url: str,
+    branch: str,
+) -> str:
+    replacements = 0
+
+    def replace_markdown(match: re.Match[str]) -> str:
+        nonlocal replacements
+        label, target = match.groups()
+        rewritten = rewrite_target(
+            target,
+            chapter_path,
+            docs_root,
+            src_dir,
+            base_url,
+            branch,
+        )
+        if rewritten is None:
+            return match.group(0)
+        replacements += 1
+        return f"[{label}]({rewritten})"
+
+    def replace_html(match: re.Match[str]) -> str:
+        nonlocal replacements
+        prefix, target, middle, label, suffix = match.groups()
+        rewritten = rewrite_target(
+            target,
+            chapter_path,
+            docs_root,
+            src_dir,
+            base_url,
+            branch,
+        )
+        if rewritten is None:
+            return match.group(0)
+        replacements += 1
+        return f"{prefix}{rewritten}{middle}{label}{suffix}"
+
+    rewritten_text = MARKDOWN_LINK_RE.sub(replace_markdown, text)
+    rewritten_text = HTML_LINK_RE.sub(replace_html, rewritten_text)
+    if replacements:
+        LOGGER.debug("rewrote %d link(s) in %s", replacements, chapter_path)
+    return rewritten_text
+
+
+def process_item(
+    item: object, docs_root: Path, base_url: str, branch: str, src_dir: str
+) -> None:
+    if not isinstance(item, dict):
+        return
+
+    chapter = item.get("Chapter")
+    if chapter is None or not isinstance(chapter, dict):
+        return
+
+    chapter_path = chapter.get("path")
+    if chapter_path:
+        LOGGER.debug("process chapter %s", chapter_path)
+        chapter["content"] = rewrite_text(
+            chapter.get("content", ""),
+            chapter_path,
+            docs_root,
+            src_dir,
+            base_url,
+            branch,
+        )
+
+    for sub_item in chapter.get("sub_items", []):
+        process_item(sub_item, docs_root, base_url, branch, src_dir)
+
+
+def process_book(
+    book: dict, docs_root: Path, base_url: str, branch: str, src_dir: str
+) -> None:
+    items = book.get("items")
+    if isinstance(items, list):
+        for item in items:
+            process_item(item, docs_root, base_url, branch, src_dir)
+        return
+
+    sections = book.get("sections")
+    if isinstance(sections, list):
+        LOGGER.debug("fallback to legacy book.sections traversal")
+        for item in sections:
+            process_item(item, docs_root, base_url, branch, src_dir)
+
+
+def run_tests() -> None:
+    class RewriteLinksTests(unittest.TestCase):
+        def setUp(self) -> None:
+            self.tmpdir = tempfile.TemporaryDirectory()
+            self.repo_root = Path(self.tmpdir.name)
+            self.docs_root = self.repo_root / "docs" / "src"
+            self.chapter_path = "modules/nixos/core/activation.md"
+            target_path = (
+                self.repo_root / "modules" / "nixos" / "core" / "activation.nix"
+            )
+            target_path.parent.mkdir(parents=True)
+            target_path.write_text("# activation\n")
+            (self.docs_root / "modules" / "nixos" / "core").mkdir(parents=True)
+            self.expected = "https://codeberg.org/Racci/nix-config/src/branch/master/modules/nixos/core/activation.nix"
+
+        def tearDown(self) -> None:
+            self.tmpdir.cleanup()
+
+        def test_activation_relative_markdown_link_rewrites(self) -> None:
+            text = "- **Entry point**: [activation.nix](../../../../../modules/nixos/core/activation.nix)"
+
+            rewritten = rewrite_text(
+                text,
+                self.chapter_path,
+                self.docs_root,
+                "src",
+                "https://codeberg.org/Racci/nix-config",
+                "master",
+            )
+
+            self.assertIn(self.expected, rewritten)
+
+        def test_activation_relative_html_link_rewrites(self) -> None:
+            text = '- <strong>Entry point</strong>: <a href="../../../../../modules/nixos/core/activation.nix">activation.nix</a>'
+
+            rewritten = rewrite_text(
+                text,
+                self.chapter_path,
+                self.docs_root,
+                "src",
+                "https://codeberg.org/Racci/nix-config",
+                "master",
+            )
+
+            self.assertIn(self.expected, rewritten)
+
+        def test_process_book_items_shape(self) -> None:
+            book = {
+                "items": [
+                    {
+                        "Chapter": {
+                            "path": self.chapter_path,
+                            "content": "- **Entry point**: [activation.nix](../../../../../modules/nixos/core/activation.nix)",
+                            "sub_items": [],
+                        }
+                    }
+                ]
+            }
+
+            process_book(
+                book,
+                self.docs_root,
+                "https://codeberg.org/Racci/nix-config",
+                "master",
+                "src",
+            )
+
+            self.assertIn(
+                self.expected,
+                book["items"][0]["Chapter"]["content"],
+            )
+
+    suite = unittest.defaultTestLoader.loadTestsFromTestCase(RewriteLinksTests)
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    raise SystemExit(0 if result.wasSuccessful() else 1)
+
+
+def main() -> None:
+    if len(sys.argv) > 1 and sys.argv[1] == "supports":
+        sys.exit(0)
+    if len(sys.argv) > 1 and sys.argv[1] in {"test", "--test"}:
+        run_tests()
+
+    configure_logging()
+
+    context, book = json.load(sys.stdin)
+    config = context["config"]
+    html = config["output"]["html"]
+    preprocessor = config["preprocessor"]["rewrite-links"]
+
+    base_url = html.get("git-repository-url")
+    if not base_url:
+        LOGGER.debug("skip rewrite: missing output.html.git-repository-url")
+        json.dump(book, sys.stdout)
+        return
+
+    branch = preprocessor.get("git-branch", "main")
+    root = Path(context.get("root", ".")).resolve(strict=False)
+    book_root = Path(context.get("book", {}).get("root", ".")).resolve(strict=False)
+    src_dir = config["book"].get("src", "src")
+    docs_root = root / src_dir if (root / src_dir).is_dir() else book_root / src_dir
+
+    LOGGER.debug(
+        "start rewrite with branch=%s src_dir=%s docs_root=%s",
+        branch,
+        src_dir,
+        docs_root,
+    )
+
+    process_book(book, docs_root, base_url, branch, src_dir)
+
+    sys.stdout.write(json.dumps(book))
+
+    sys.stdout.write("\n")
+    sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/preprocessor/validate-includes.py
+++ b/docs/preprocessor/validate-includes.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+import re
+import sys
+from pathlib import Path
+
+include_pattern = re.compile(r"^\s*\{\{#include\s+([^\s}]+)")
+
+
+def main():
+    if len(sys.argv) > 1 and sys.argv[1] == "supports":
+        sys.exit(0)
+
+    src_root = Path("src").resolve()
+    errors = []
+
+    for markdown_path in sorted(src_root.rglob("*.md")):
+        content = markdown_path.read_text(encoding="utf-8")
+        for line_number, line in enumerate(content.splitlines(), start=1):
+            match = include_pattern.match(line)
+            if match is None:
+                continue
+
+            include_target = match.group(1)
+            resolved_path = (markdown_path.parent / include_target).resolve()
+
+            if not resolved_path.is_file():
+                pd_path = markdown_path.relative_to(src_root)
+                try:
+                    res_path = resolved_path.relative_to(src_root.parent)
+                except ValueError:
+                    res_path = str(resolved_path)
+                errors.append(
+                    f"{pd_path}:{line_number}: include target not found: {include_target} -> {res_path}"
+                )
+
+    if errors:
+        print("mdBook include validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/search.nix
+++ b/docs/search.nix
@@ -34,5 +34,9 @@ in
 mkMultiSearch {
   title = "RacciDev Search";
   baseHref = "/nix-config/search/";
-  scopes = rootModules |> map (path: mkRacciDevModule path "${self}/modules/nixos/${path}");
+  scopes =
+    rootModules |> map (path: mkRacciDevModule path "${self}/modules/nixos/${path}/default.nix");
+}
+// {
+  passthru.discovery = false;
 }

--- a/docs/serve.nix
+++ b/docs/serve.nix
@@ -15,4 +15,6 @@ writeShellApplication {
     ${lib.optionalString open-webpage "xdg-open http://localhost:8080"}
     wait
   '';
+
+  passthru.discovery = false;
 }

--- a/docs/site.nix
+++ b/docs/site.nix
@@ -2,14 +2,71 @@
   pkgs,
   lib,
   search,
+  moduleOptionsJSON,
+  allModules,
+
+  discoverModules,
+  mkNixosModuleOptions,
+  mkHomeManagerModuleOptions,
   ...
 }:
+let
+  # Python script packaged as store path so it can be referenced by full path
+  # inside sandbox without needing python3 in PATH.
+  genOptionsMd = pkgs.writeText "gen-options-md.py" (
+    builtins.readFile ./preprocessor/gen-options-md.py
+  );
+  py3 = "${pkgs.python3}/bin/python3";
+
+  # Dynamically generate option fragments for all discovered modules
+  optionFragments = lib.mapAttrsToList (name: module: {
+    json = moduleOptionsJSON.${name};
+    prefix = module.prefix;
+    output = "generated/${module.outputName}-options.md";
+  }) allModules;
+
+  generateOptionFragments = lib.concatMapStringsSep "\n" (fragment: ''
+    ${py3} ${genOptionsMd} \
+      ${fragment.json} \
+      "${fragment.prefix}" \
+      ${fragment.output}
+  '') optionFragments;
+
+  mdBookRewriteLinks = pkgs.writers.writePython3Bin "mdbook-rewrite-links" {
+    flakeIgnore = [
+      "E265"
+      "E501"
+    ];
+  } ./preprocessor/rewrite-links.py;
+  mdBookValidateIncludes = pkgs.writers.writePython3Bin "mdbook-validate-includes" {
+    flakeIgnore = [
+      "E265"
+      "E501"
+    ];
+  } ./preprocessor/validate-includes.py;
+
+  readme =
+    pkgs.runCommand "readme"
+      {
+        start = "<!-- START DOCS -->";
+        end = "<!-- STOP DOCS -->";
+        src = ../README.md;
+      }
+      ''
+        # extract relevant section of the README
+        sed -n "/$start/,/$end/p" $src > $out
+      '';
+in
 pkgs.stdenv.mkDerivation (finalAttrs: {
   name = "raccidev-docs";
   __structuredAttrs = true;
 
   phase = [ "buildPhase" ];
-  builtInputs = [ pkgs.mdbook ];
+  nativeBuildInputs = [
+    pkgs.mdbook
+    mdBookRewriteLinks
+    mdBookValidateIncludes
+  ];
 
   src = lib.fileset.toSource {
     root = ../.;
@@ -21,8 +78,10 @@ pkgs.stdenv.mkDerivation (finalAttrs: {
           "css"
           "js"
           "md"
+          "py"
           "toml"
         ]
+
       ) ./.)
     ];
   };
@@ -33,27 +92,42 @@ pkgs.stdenv.mkDerivation (finalAttrs: {
     mv ./docs/* ./ && rmdir ./docs
 
     ${pkgs.fd}/bin/fd
-    substituteInPlace ./src/index.md \
-      --replace-fail "@README@" "$(cat ${finalAttrs.passthru.readme})"
 
+    # ── Option reference fragments ───────────────────────────────────────
+    # Generate Markdown fragments for all docs pages that embed module
+    # options via {{#include}}.
+    mkdir -p generated
+
+    ${generateOptionFragments}
+
+    # ── README substitution ───────────────────────────────────────────────
+    substituteInPlace ./src/index.md \
+      --replace-fail "@README@" "$(cat ${readme})"
+
+    # ── Include validation ────────────────────────────────────────────────
+    ${lib.getExe mdBookValidateIncludes}
+
+    # ── Build the mdbook site ─────────────────────────────────────────────
     ${lib.getExe pkgs.mdbook} build
+
     cp -r ./book/* "$out"
+
+    # ── Search static files ───────────────────────────────────────────────
     mkdir -p "$out/search"
     cp -r ${finalAttrs.passthru.search}/* "$out/search"
+
   '';
 
   passthru = {
-    inherit search;
-    readme =
-      pkgs.runCommand "readme"
-        {
-          start = "<!-- START DOCS -->";
-          end = "<!-- STOP DOCS -->";
-          src = ../README.md;
-        }
-        ''
-          # extract relevant section of the README
-          sed -n "/$start/,/$end/p" $src > $out
-        '';
+    inherit
+      search
+      readme
+      moduleOptionsJSON
+      allModules
+      discoverModules
+      mkNixosModuleOptions
+      mkHomeManagerModuleOptions
+      ;
+    discovery = false;
   };
 })

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,4 +1,4 @@
-[Introduction](README.md)
+[Introduction](index.md)
 
 # User Guides
 
@@ -82,6 +82,6 @@
 
 - [Overview](lib/overview.md)
 
-______________________________________________________________________
+---
 
 [RacciDev Options Search](./search/index.html)

--- a/docs/src/components/io_guardian.md
+++ b/docs/src/components/io_guardian.md
@@ -9,12 +9,10 @@ It provides graceful startup and shutdown coordination between the database host
 The system consists of two components:
 
 1. **Guardian Server** (runs on client servers)
-
    - WebSocket server that listens for commands from the coordinator
    - Executes drain/undrain commands by controlling `io-databases.target`
 
 1. **Guardian Client** (runs on the IO Host)
-
    - WebSocket client that connects to all guardian servers
    - Sends `undrain` command after databases are online (start dependent services)
    - Sends `drain` command before database shutdown (stop dependent services)
@@ -109,16 +107,16 @@ Services listed here will:
 
 ### On Client Servers
 
-| Unit | Type | Description |
-| --------------------------------- | ------- | ------------------------------------------------ |
-| `io-guardian.service` | simple | WebSocket server for receiving commands |
-| `io-databases.target` | target | Represents "databases are online" |
-| `wait-for-io-databases.service`| oneshot | Waits for databases at boot (runs once) |
+| Unit                            | Type    | Description                             |
+| ------------------------------- | ------- | --------------------------------------- |
+| `io-guardian.service`           | simple  | WebSocket server for receiving commands |
+| `io-databases.target`           | target  | Represents "databases are online"       |
+| `wait-for-io-databases.service` | oneshot | Waits for databases at boot (runs once) |
 
 ### On nixio
 
-| Unit | Type | Description |
-| ---------------------------------- | ------- | ------------------------------------------ |
+| Unit                              | Type    | Description                           |
+| --------------------------------- | ------- | ------------------------------------- |
 | `io-database-coordinator.service` | oneshot | Sends undrain on start, drain on stop |
 
 ## Troubleshooting

--- a/docs/src/components/server_monitoring.md
+++ b/docs/src/components/server_monitoring.md
@@ -11,7 +11,6 @@ cross-host discovery.
 The system consists of three layers:
 
 1. **Exporters** (run on all servers)
-
    - node_exporter for system-level metrics (CPU, memory, disk, network, per-process stats)
    - Grafana Alloy for shipping journald logs and Caddy access logs to Loki
    - Caddy access logs are parsed as JSON at ingest time so `detected_level`, `logger`, and `status` are available in Loki
@@ -19,14 +18,12 @@ The system consists of three layers:
    - Application-specific exporters (Caddy, PostgreSQL, Redis) enabled automatically
 
 1. **Collectors** (run on the monitoring primary host)
-
    - Prometheus for metrics aggregation with 90-day retention
    - Loki for log aggregation with 90-day retention
    - Alertmanager for alert routing and notifications
    - OTLP/HTTP ingestion on `otlp.<domain>` with bearer-token authentication
 
 1. **Visualization** (runs on the monitoring primary host)
-
    - Grafana with provisioned datasources and dashboards
    - Native Kanidm OAuth2 authentication
 
@@ -63,27 +60,9 @@ Monitoring is enabled by default on all servers (`server.monitoring.enable = tru
 The monitoring primary host is configured via the `allocations.server.monitoringPrimaryHost`
 option, currently set to `nixmon`.
 
-### Options Reference
+### Options
 
-All options live under `server.monitoring`:
-
-| Option | Type | Default | Description |
-| ----------------------------------------- | ------ | ------- | --------------------------------------------------------------- |
-| `enable` | bool | `true` | Enable monitoring for this server |
-| `retention.metrics` | string | `"90d"` | Prometheus TSDB retention period |
-| `retention.logs` | string | `"90d"` | Loki log retention period |
-| `exporters.node.enable` | bool | `true` | Enable node_exporter |
-| `exporters.caddy.enable` | bool | auto | Enable Caddy metrics (auto if proxy configured) |
-| `exporters.postgres.enable` | bool | auto | Enable PostgreSQL exporter (auto on IO host) |
-| `exporters.redis.enable` | bool | auto | Enable Redis exporter (auto on IO host) |
-| `logs.enable` | bool | `true` | Enable Alloy log shipping |
-| `collector.enable` | bool | auto | Enable collectors (auto on monitoring host) |
-| `collector.grafana.kanidm.enable` | bool | `true` | Enable Kanidm OAuth2 for Grafana |
-| `collector.otlp.enable` | bool | auto | Enable authenticated OTLP/HTTP ingestion on the monitoring host |
-| `collector.alerting.enable` | bool | `true` | Enable Alertmanager |
-| `collector.alerting.homeAssistant.enable` | bool | `false` | Enable Home Assistant webhook alerting |
-| `collector.alerting.nextcloudTalk.enable` | bool | `false` | Enable Nextcloud Talk webhook alerting |
-| `collector.proxmox.enable` | bool | `true` | Enable Proxmox VE metrics collection |
+{{#include ../../generated/server-monitoring-options.md}}
 
 ### Auto-Detection
 
@@ -132,12 +111,12 @@ under `KANIDM/OAUTH2/GRAFANA_SECRET` (the Kanidm provisioning side).
 
 The module configures four virtual hosts on nixmon:
 
-| Service | Subdomain | Access |
+| Service    | Subdomain             | Access                        |
 | ---------- | --------------------- | ----------------------------- |
-| Grafana | `grafana.<domain>` | Public |
-| OTLP | `otlp.<domain>` | Public, bearer token required |
-| Prometheus | `prometheus.<domain>` | LAN |
-| Loki | `loki.<domain>` | LAN |
+| Grafana    | `grafana.<domain>`    | Public                        |
+| OTLP       | `otlp.<domain>`       | Public, bearer token required |
+| Prometheus | `prometheus.<domain>` | LAN                           |
+| Loki       | `loki.<domain>`       | LAN                           |
 
 Grafana remains protected by the existing Kanidm-backed login flow. The OTLP
 ingestion endpoint is intended for machine-to-machine clients and requires an
@@ -151,13 +130,13 @@ primary host's Caddy configuration.
 
 The following alerts are configured by default:
 
-| Alert | Condition | Severity |
+| Alert               | Condition                                | Severity |
 | ------------------- | ---------------------------------------- | -------- |
-| `HostDown` | `up{job="node"} == 0` for 2 minutes | Critical |
+| `HostDown`          | `up{job="node"} == 0` for 2 minutes      | Critical |
 | `DiskSpaceCritical` | Root filesystem < 10% free for 5 minutes | Critical |
-| `HighCPUUsage` | CPU usage > 90% for 5 minutes | Warning |
-| `HighMemoryUsage` | Memory usage > 90% for 5 minutes | Warning |
-| `ServiceDown` | `up{job!="node"} == 0` for 2 minutes | Critical |
+| `HighCPUUsage`      | CPU usage > 90% for 5 minutes            | Warning  |
+| `HighMemoryUsage`   | Memory usage > 90% for 5 minutes         | Warning  |
+| `ServiceDown`       | `up{job!="node"} == 0` for 2 minutes     | Critical |
 
 Alerts are routed to:
 

--- a/docs/src/components/server_monitoring.md
+++ b/docs/src/components/server_monitoring.md
@@ -62,7 +62,7 @@ option, currently set to `nixmon`.
 
 ### Options
 
-{{#include ../../generated/server-monitoring-options.md}}
+{{#include ../generated/server-monitoring-options.md}}
 
 ### Auto-Detection
 

--- a/docs/src/development/declarative_gnome_dconf.md
+++ b/docs/src/development/declarative_gnome_dconf.md
@@ -2,17 +2,17 @@
 
 When changing GNOME or GNOME extension settings, it is recommended to use dconf2nix and cherry pick its output. This allows for easy configuration using the GUI, but requires copying the settings back into the respective dconf settings in home-manager to save them.
 
-______________________________________________________________________
+---
 
 ## DConf Locations
 
 The locations for where to save DConf settings to is:
 
-- [Base.nix](../home/shared/desktop/gnome/base.nix) for standard GNOME DConf Settings.
-- [Extensions.nix](../home/shared/desktop/gnome/extensions.nix) for Extensions DConf Settings
+- [Base.nix](../../../home/shared/desktop/gnome/dconf-base.nix) for standard GNOME DConf Settings.
+- [Extensions.nix](../../../home/shared/desktop/gnome/dconf-extensions.nix) for Extensions DConf Settings
 - Per User Settings should be saved in the format of `home/${username}/desktop/gnome.nix`
 
-______________________________________________________________________
+---
 
 ## Getting the Output
 

--- a/docs/src/hosts/overview.md
+++ b/docs/src/hosts/overview.md
@@ -37,7 +37,7 @@ Global options still shared across all hosts remain in `hosts/shared/global/`.
 
 - [Adding a New Host](../development/adding_a_new_host.md)
 
-______________________________________________________________________
+---
 
 ## Decky Loader Lifecycle
 

--- a/docs/src/lib/overview.md
+++ b/docs/src/lib/overview.md
@@ -16,7 +16,7 @@ The `lib` directory contains custom Nix functions and builders used throughout t
   - `package.nix`: Custom package definitions and derivation helpers.
   - `persistence.nix`: Helpers for managing path persistence in ephemeral (TempFS) environments.
   - `strings.nix`: String manipulation and formatting utilities.
-- `lib/builders/`: Contains specialized builders for system and home configurations.
+- `lib/builders/`: Specialized builders for system and home configurations. Builders forward shared module arguments (e.g. `importExternals` and repo-level args) into both NixOS and nested Home Manager `extraSpecialArgs`, enabling modules that conditionally import external inputs.
 
 ## Key Options/Knobs
 

--- a/docs/src/modules/flake/allocations.md
+++ b/docs/src/modules/flake/allocations.md
@@ -25,6 +25,8 @@ When `mkSystem` builds a NixOS configuration, it receives the `allocations` attr
 
 ## Options
 
+{{#include ../../../generated/allocations-options.md}}
+
 ### `allocations.accelerators`
 
 Maps hostnames to their available hardware accelerators (`cuda`, `rocm`). Used by the builder system to configure `nixpkgs` with the correct `cudaSupport` / `rocmSupport` flags per host.
@@ -91,10 +93,10 @@ Imported by the Home-Manager builder. Currently a no-op (`mkMerge []`) — exist
 
 ## Source Files
 
-| File | Role |
-|------|------|
-| [`modules/flake/allocations.nix`](../../../modules/flake/allocations.nix) | Option definitions |
-| [`modules/flake/apply/system.nix`](../../../modules/flake/apply/system.nix) | NixOS system apply |
-| [`modules/flake/apply/home-manager.nix`](../../../modules/flake/apply/home-manager.nix) | Home-Manager apply (placeholder) |
-| [`flake/nixos/flake-module.nix`](../../../flake/nixos/flake-module.nix) | Actual configuration values |
-| [`lib/builders/default.nix`](../../../lib/builders/default.nix) | Builder that consumes allocations |
+| File                                                                                       | Role                              |
+| ------------------------------------------------------------------------------------------ | --------------------------------- |
+| [`modules/flake/allocations.nix`](../../../../modules/flake/allocations.nix)               | Option definitions                |
+| [`modules/flake/apply/system.nix`](../../../../modules/flake/apply/system.nix)             | NixOS system apply                |
+| [`modules/flake/apply/home-manager.nix`](../../../../modules/flake/apply/home-manager.nix) | Home-Manager apply (placeholder)  |
+| [`flake/nixos/flake-module.nix`](../../../../flake/nixos/flake-module.nix)                 | Actual configuration values       |
+| [`lib/builders/default.nix`](../../../../lib/builders/default.nix)                         | Builder that consumes allocations |

--- a/docs/src/modules/home-manager/ai.md
+++ b/docs/src/modules/home-manager/ai.md
@@ -6,7 +6,7 @@ This page documents the Home-Manager module at:
 
 It configures editor/agent tooling for AI-assisted development, centered around OpenCode and shared skill directories.
 
-______________________________________________________________________
+---
 
 ## What this module sets up
 
@@ -34,54 +34,13 @@ When enabled, the module:
   - `.local/share/opencode`
   - `.local/state/opencode`
 
-______________________________________________________________________
+---
 
 ## Options
 
-### `purpose.development.editors.ai.enable`
+{{#include ../../../generated/purpose-development-editors-ai-options.md}}
 
-| | |
-|---|---|
-| Type | `bool` |
-| Default | `false` |
-
-Enable AI tools and assistant/editor integrations for the user profile.
-
-______________________________________________________________________
-
-### `purpose.development.editors.ai.includeDefaults`
-
-| | |
-|---|---|
-| Type | `bool` |
-| Default | `true` |
-
-Whether to include the module’s built-in skills and agents from:
-
-- `modules/home-manager/purpose/development/editors/ai/skills`
-- `modules/home-manager/purpose/development/editors/ai/agents`
-
-Set to `false` for a minimal setup with only base OpenCode configuration.
-
-______________________________________________________________________
-
-### `purpose.development.editors.ai.skills`
-
-| | |
-|---|---|
-| Type | `list of string` |
-| Default | `[]` |
-
-Additional skill source paths to register globally under `~/.agents/skills`.
-
-Each entry should point to a skill directory (for example from a flake input or from this repository). The basename of each source path is used as the destination directory name.
-
-Example:
-
-- `"${inputs.my-skill-repo}/skills/my-skill"`
-- `"${self}/skills/another-skill"`
-
-______________________________________________________________________
+---
 
 ## Usage example
 
@@ -99,7 +58,7 @@ ______________________________________________________________________
 }
 ```
 
-______________________________________________________________________
+---
 
 ## Notes
 

--- a/docs/src/modules/home-manager/diy.md
+++ b/docs/src/modules/home-manager/diy.md
@@ -2,62 +2,33 @@
 
 This section documents the Home-Manager modules under `purpose.diy`, which provide tooling and configuration for hardware tinkering, 3D printing, and related maker activities.
 
-______________________________________________________________________
+---
 
 ## Printing
 
 The printing module installs 3D-printing software and wires up persistent storage so that settings survive reboots on impermanence-based systems.
 
-- **Entry point**: `modules/home-manager/purpose/diy/printing.nix`
+- **Entry point**: [printing.nix](../../../../modules/home-manager/purpose/diy/printing.nix)
 
 ### Options
 
-#### `purpose.diy.printing.enable`
-
-| | |
-|---|---|
-| Type | `bool` |
-| Default | `false` |
-
-Enables 3D-printing support. Installs OrcaSlicer and LycheeSlicer and registers their configuration directories for persistence.
-
-______________________________________________________________________
+{{#include ../../../generated/purpose-diy-printing-options.md}}
 
 ### Git Sync
 
 The `gitSync` sub-module adds a long-running systemd user service that watches the OrcaSlicer profile directory and automatically creates a git commit every time a profile file is added, changed, or removed. This gives you a full revision history of your slicer settings with zero manual effort.
 
-#### `purpose.diy.printing.gitSync.enable`
-
-| | |
-|---|---|
-| Type | `bool` |
-| Default | `false` |
-
-Enable the OrcaSlicer git auto-commit watcher. Requires `purpose.diy.printing.enable = true`.
-
-#### `purpose.diy.printing.gitSync.repoPath`
-
-| | |
-|---|---|
-| Type | `string` |
-| Default | `"${config.home.homeDirectory}/.config/OrcaSlicer/user/default"` |
-
-Absolute path to the directory that will be managed as a git repository. The directory is initialised automatically the first time the watcher service starts, so it does not need to exist at activation time.
-
-The default points at the standard OrcaSlicer per-user profile directory, which contains the `filament/`, `process/`, and `machine/` sub-directories, so all profile types are tracked without any additional configuration.
-
-______________________________________________________________________
+---
 
 ### Commit Message Convention
 
 Commit messages are generated automatically based on the type of filesystem event and the location of the file within the repository:
 
-| Event | Commit message format |
-|---|---|
-| File added / created | `feat(<type>): added <name>` |
-| File modified | `refactor(<type>): updated <name>` |
-| File deleted | `chore(<type>): removed <name>` |
+| Event                | Commit message format              |
+| -------------------- | ---------------------------------- |
+| File added / created | `feat(<type>): added <name>`       |
+| File modified        | `refactor(<type>): updated <name>` |
+| File deleted         | `chore(<type>): removed <name>`    |
 
 Where:
 
@@ -72,7 +43,7 @@ refactor(process): updated Standard_0.2mm_Quality
 chore(machine): removed Prusa_MK4S
 ```
 
-______________________________________________________________________
+---
 
 ### How It Works
 
@@ -82,7 +53,7 @@ ______________________________________________________________________
 1. All pending changes are then committed **one file at a time**, each with an individually crafted commit message.
 1. If the watched directory does not yet exist (e.g. OrcaSlicer has never been run), the service polls every 10 seconds until it appears, then initialises the repository and starts watching.
 
-______________________________________________________________________
+---
 
 ### Usage Example
 
@@ -102,7 +73,7 @@ ______________________________________________________________________
 }
 ```
 
-______________________________________________________________________
+---
 
 ### Operational Notes
 

--- a/docs/src/modules/home-manager/programs/list_ephemeral.md
+++ b/docs/src/modules/home-manager/programs/list_ephemeral.md
@@ -4,7 +4,7 @@
 
 ## Options
 
-{{#include ../../../../generated/programs-list-ephemeral-options.md}}
+{{#include ../../../generated/programs-list-ephemeral-options.md}}
 
 ## Usage
 

--- a/docs/src/modules/home-manager/programs/list_ephemeral.md
+++ b/docs/src/modules/home-manager/programs/list_ephemeral.md
@@ -4,27 +4,7 @@
 
 ## Options
 
-```
-programs.list-ephemeral.enable
-```
-
-Enable the list-ephemeral integration and generate the runtime config at:
-
-```
-$XDG_CONFIG_HOME/list-ephemeral/config.json
-```
-
-```
-programs.list-ephemeral.extraExcludes
-```
-
-Additional exclude patterns for the fd scan.
-
-```
-programs.list-ephemeral.extraIncludes
-```
-
-Additional paths to always include as candidates. Relative paths are treated as relative to `$HOME`.
+{{#include ../../../../generated/programs-list-ephemeral-options.md}}
 
 ## Usage
 
@@ -36,17 +16,17 @@ list-ephemeral
 
 ### TUI Keybindings
 
-| Key | Action |
-|-----|--------|
-| `/` | Enable search mode (type to fuzzy filter) |
-| `Escape` | Disable search and clear query |
-| `Ctrl-P` | Open program filter (gum picker) |
-| `Ctrl-X` | Clear program filter |
-| `Space` | Toggle selection and move down |
-| `Ctrl-A` | Select all |
-| `Ctrl-D` | Deselect all |
-| `Ctrl-C` | Quit (standard fzf behavior) |
-| `Enter` | Confirm selection |
+| Key      | Action                                    |
+| -------- | ----------------------------------------- |
+| `/`      | Enable search mode (type to fuzzy filter) |
+| `Escape` | Disable search and clear query            |
+| `Ctrl-P` | Open program filter (gum picker)          |
+| `Ctrl-X` | Clear program filter                      |
+| `Space`  | Toggle selection and move down            |
+| `Ctrl-A` | Select all                                |
+| `Ctrl-D` | Deselect all                              |
+| `Ctrl-C` | Quit (standard fzf behavior)              |
+| `Enter`  | Confirm selection                         |
 
 **Note:** In browse mode (default), typing text will appear in the prompt but won't filter results. Press `/` to enable search filtering.
 

--- a/docs/src/modules/nixos/core/activation.md
+++ b/docs/src/modules/nixos/core/activation.md
@@ -2,28 +2,21 @@
 
 Reports system generation changes during NixOS activation.
 
-- **Entry point**: `modules/nixos/core/activation.nix`
+- **Entry point**: [activation.nix](../../../../../modules/nixos/core/activation.nix)
 
-______________________________________________________________________
+---
 
 ## Overview
 
 This module adds activation-time diff reporting with [`nvd`](https://github.com/vlinkz/nvd). During activation it compares previous and new system generations and prints package and closure changes.
 
-______________________________________________________________________
+---
 
 ## Options
 
-### `core.activation.enable`
+{{#include ../../../../generated/core-activation-options.md}}
 
-| | |
-|---|---|
-| Type | `bool` |
-| Default | `config.core.enable` |
-
-Enable activation diff reporting.
-
-______________________________________________________________________
+---
 
 ## Behaviour
 
@@ -35,7 +28,7 @@ When enabled, module installs `system.activationScripts.report-changes` that:
 
 If no previous generation exists yet, script does nothing.
 
-______________________________________________________________________
+---
 
 ## Usage Example
 
@@ -45,7 +38,7 @@ ______________________________________________________________________
 }
 ```
 
-______________________________________________________________________
+---
 
 ## Operational Notes
 

--- a/docs/src/modules/nixos/core/auto_upgrade.md
+++ b/docs/src/modules/nixos/core/auto_upgrade.md
@@ -2,37 +2,21 @@
 
 Schedules automatic NixOS upgrades from flake host outputs.
 
-- **Entry point**: `modules/nixos/core/auto-upgrade.nix`
+- **Entry point**: [auto-upgrade.nix](../../../../../modules/nixos/core/auto-upgrade.nix)
 
-______________________________________________________________________
+---
 
 ## Overview
 
 This module configures `system.autoUpgrade` to rebuild host from `github:DaRacci/nix-config#<host>`. It also applies resource limits to `nixos-upgrade.service` so scheduled upgrades run with lower CPU and IO priority.
 
-______________________________________________________________________
+---
 
 ## Options
 
-### `core.auto-upgrade.enable`
+{{#include ../../../../generated/core-auto-upgrade-options.md}}
 
-| | |
-|---|---|
-| Type | `bool` |
-| Default | `true` |
-
-Enable automatic upgrade configuration.
-
-### `core.auto-upgrade.hostName`
-
-| | |
-|---|---|
-| Type | `string` |
-| Default | `config.networking.hostName` |
-
-Host output name used in flake reference `github:DaRacci/nix-config#<hostName>`.
-
-______________________________________________________________________
+---
 
 ## Behaviour
 
@@ -45,7 +29,7 @@ When enabled, module configures:
 
 Auto-upgrade itself only turns on when flake has `self.rev`, meaning repository is in clean revisioned state.
 
-______________________________________________________________________
+---
 
 ## Usage Example
 
@@ -58,7 +42,7 @@ ______________________________________________________________________
 }
 ```
 
-______________________________________________________________________
+---
 
 ## Operational Notes
 

--- a/docs/src/modules/nixos/core/containers.md
+++ b/docs/src/modules/nixos/core/containers.md
@@ -2,28 +2,21 @@
 
 Enables Docker-based container runtime defaults.
 
-- **Entry point**: `modules/nixos/core/containers.nix`
+- **Entry point**: [containers.nix](../../../../../modules/nixos/core/containers.nix)
 
-______________________________________________________________________
+---
 
 ## Overview
 
 This module turns on Docker as primary container backend and configures OCI containers to use Docker. It also enables weekly image pruning and persists Docker state directories.
 
-______________________________________________________________________
+---
 
 ## Options
 
-### `core.containers.enable`
+{{#include ../../../../generated/core-containers-options.md}}
 
-| | |
-|---|---|
-| Type | `bool` |
-| Default | disabled |
-
-Enable shared container runtime configuration.
-
-______________________________________________________________________
+---
 
 ## Behaviour
 
@@ -39,7 +32,7 @@ When enabled, module:
 
 Persisted directories include `overlay2`, `image`, `volumes`, `containers`, `containerd`, and `buildkit`.
 
-______________________________________________________________________
+---
 
 ## Usage Example
 
@@ -49,7 +42,7 @@ ______________________________________________________________________
 }
 ```
 
-______________________________________________________________________
+---
 
 ## Operational Notes
 

--- a/docs/src/modules/nixos/core/default.md
+++ b/docs/src/modules/nixos/core/default.md
@@ -8,43 +8,9 @@ Documents shared NixOS core modules used across hosts.
 
 It also defines top-level baseline options under `core.*` that control this shared behavior for most hosts.
 
-## Top-Level Options
+## Options
 
-### `core.enable`
-
-| | |
-|---|---|
-| Type | `bool` |
-| Default | `true` |
-
-Master switch for shared core baseline.
-
-### `core.audio.enable`
-
-| | |
-|---|---|
-| Type | `bool` |
-| Default | `!config.host.device.isHeadless` |
-
-Enable shared audio stack on non-headless hosts by default.
-
-### `core.bluetooth.enable`
-
-| | |
-|---|---|
-| Type | `bool` |
-| Default | `!config.host.device.isHeadless` |
-
-Enable Bluetooth support on non-headless hosts by default.
-
-### `core.network.enable`
-
-| | |
-|---|---|
-| Type | `bool` |
-| Default | `!config.host.device.isVirtual` |
-
-Enable shared network baseline on non-virtual hosts by default.
+{{#include ../../../../generated/core-options.md}}
 
 ## Baseline Behaviour
 

--- a/docs/src/modules/nixos/core/display_manager.md
+++ b/docs/src/modules/nixos/core/display_manager.md
@@ -2,9 +2,9 @@
 
 Configures display manager for graphical sessions on desktop and laptop hosts.
 
-- **Entry point**: `modules/nixos/core/display-manager.nix`
+- **Entry point**: [display-manager.nix](../../../../../modules/nixos/core/display-manager.nix)
 
-______________________________________________________________________
+---
 
 ## Overview
 
@@ -12,20 +12,13 @@ This module sets up [greetd](https://sr.ht/~kennylevinsen/greetd/) with [tuigree
 
 When session packages are present in `services.displayManager.sessionPackages`, module also passes both Wayland and X session directories to `tuigreet`.
 
-______________________________________________________________________
+---
 
 ## Options
 
-### `core.display-manager.enable`
+{{#include ../../../../generated/core-display-manager-options.md}}
 
-| | |
-|---|---|
-| Type | `bool` |
-| Default | `!config.host.device.isHeadless` |
-
-Enable display manager configuration. Automatically disabled on headless hosts.
-
-______________________________________________________________________
+---
 
 ## Behaviour
 
@@ -38,7 +31,7 @@ When enabled, greetd starts with tuigreet providing terminal-based greeter that:
 
 Greeter cache is persisted to `/var/cache/tuigreet` through `host.persistence.directories`.
 
-______________________________________________________________________
+---
 
 ## Usage Example
 
@@ -52,7 +45,7 @@ ______________________________________________________________________
 }
 ```
 
-______________________________________________________________________
+---
 
 ## Operational Notes
 

--- a/docs/src/modules/nixos/core/gaming.md
+++ b/docs/src/modules/nixos/core/gaming.md
@@ -2,28 +2,31 @@
 
 Enables gaming, VR, and Steam-focused desktop features.
 
-- **Entry point**: `modules/nixos/core/gaming.nix`
+- **Entry point**: [gaming.nix](../../../../../modules/nixos/core/gaming.nix)
 
-______________________________________________________________________
+---
 
 ## Overview
 
 This module configures desktop gaming stack around Steam, 32-bit graphics support, Android ADB tools, and WiVRn streaming. It also adds firewall rules, udev rules for common gaming devices, and optional Decky Loader lifecycle integration.
 
-______________________________________________________________________
+---
 
 ## Options
 
-### `core.gaming.enable`
+{{#include ../../../../generated/purpose-gaming-options.md}}
 
-| | |
-|---|---|
-| Type | `bool` |
-| Default | disabled |
+{{#include ../../../../generated/purpose-gaming-gamemode-options.md}}
 
-Enable gaming feature set.
+{{#include ../../../../generated/purpose-gaming-minecraft-options.md}}
+{{#include ../../../../generated/purpose-gaming-modding-options.md}}
+{{#include ../../../../generated/purpose-gaming-osu-options.md}}
+{{#include ../../../../generated/purpose-gaming-roblox-options.md}}
+{{#include ../../../../generated/purpose-gaming-simulator-options.md}}
+{{#include ../../../../generated/purpose-gaming-steam-options.md}}
+{{#include ../../../../generated/purpose-gaming-vr-options.md}}
 
-______________________________________________________________________
+---
 
 ## Behaviour
 
@@ -43,7 +46,7 @@ When enabled, module:
 
 It also overlays `gamescope-session` to use 4K resolution and wider refresh limits, and opens firewall ports UDP `41492`, `9943`, `9944` plus TCP `8082`, `9943`, `9944`, and `24070`.
 
-______________________________________________________________________
+---
 
 ## Decky Loader Integration
 
@@ -53,7 +56,7 @@ If `config.jovian.decky-loader.enable` is true, module additionally:
 - adds Polkit rule so active local user can start and stop `decky-loader.service`, and
 - when Home Manager is present, installs user service that polls Steam PID file, starts Decky Loader once Steam is running, and stops it after Steam exits.
 
-______________________________________________________________________
+---
 
 ## Usage Example
 
@@ -63,7 +66,7 @@ ______________________________________________________________________
 }
 ```
 
-______________________________________________________________________
+---
 
 ## Operational Notes
 

--- a/docs/src/modules/nixos/core/generators.md
+++ b/docs/src/modules/nixos/core/generators.md
@@ -2,9 +2,9 @@
 
 Configures image and container generator support for shared NixOS hosts.
 
-- **Entry point**: `modules/nixos/core/generators.nix`
+- **Entry point**: [generators.nix](../../../../../modules/nixos/core/generators.nix)
 
-______________________________________________________________________
+---
 
 ## Overview
 
@@ -12,56 +12,13 @@ This module imports `nixos-generators` formats and exposes `core.generators` opt
 
 Current focus is Proxmox LXC image generation. When enabled for virtual hosts, module adds activation logic that prompts for SSH host private key on first boot, validates it with `ssh-keygen`, and stores it under `/persist/etc/ssh/ssh_host_ed25519_key` so later secret management can install it into `/etc/ssh`.
 
-______________________________________________________________________
+---
 
 ## Options
 
-### `core.generators.enable`
+{{#include ../../../../generated/core-generators-options.md}}
 
-| | |
-|---|---|
-| Type | `bool` |
-| Default | `config.core.enable` |
-
-Enable shared generator configuration and import generator formats from `nixos-generators`.
-
-### `core.generators.proxmoxLXC.enable`
-
-| | |
-|---|---|
-| Type | `bool` |
-| Default | `cfg.enable && config.host.device.isVirtual` |
-
-Enable Proxmox LXC generator integration. Adds first-boot SSH private key prompt and Proxmox LXC format configuration.
-
-### `core.generators.proxmoxLXC.sedPath`
-
-| | |
-|---|---|
-| Type | `path` |
-| Default | `getExe' pkgs.busybox "sed"` |
-
-Path to `sed` binary used to extract pasted OpenSSH private key block from terminal input.
-
-### `core.generators.proxmoxLXC.sshKeygenPath`
-
-| | |
-|---|---|
-| Type | `path` |
-| Default | `getExe' pkgs.openssh "ssh-keygen"` |
-
-Path to `ssh-keygen` binary used to validate pasted private key and derive matching public key.
-
-### `core.generators.proxmoxLXC.clearPath`
-
-| | |
-|---|---|
-| Type | `path` |
-| Default | `getExe' pkgs.busybox "clear"` |
-
-Path to `clear` binary used between failed interactive prompt attempts.
-
-______________________________________________________________________
+---
 
 ## Assertions and Behaviour
 
@@ -73,7 +30,7 @@ If activation runs without controlling terminal, prompt is skipped and activatio
 - passes `ssh-keygen -y`, and
 - matches public key already present at `/etc/ssh/ssh_host_ed25519_key.pub`.
 
-______________________________________________________________________
+---
 
 ## Usage Example
 
@@ -89,7 +46,7 @@ ______________________________________________________________________
 }
 ```
 
-______________________________________________________________________
+---
 
 ## Operational Notes
 

--- a/docs/src/modules/nixos/core/groups.md
+++ b/docs/src/modules/nixos/core/groups.md
@@ -2,28 +2,21 @@
 
 Applies shared extra group membership to all declared users.
 
-- **Entry point**: `modules/nixos/core/groups.nix`
+- **Entry point**: [groups.nix](../../../../../modules/nixos/core/groups.nix)
 
-______________________________________________________________________
+---
 
 ## Overview
 
 This module defines `core.defaultGroups`, shared list of Unix groups appended to every configured standard user. Other core modules use this option to grant access to subsystems like audio, networking, Docker, printing, and virtualisation.
 
-______________________________________________________________________
+---
 
 ## Options
 
-### `core.defaultGroups`
+{{#include ../../../../generated/core-groups-options.md}}
 
-| | |
-|---|---|
-| Type | `list of string` |
-| Default | `[]` |
-
-Additional groups added to all users by default.
-
-______________________________________________________________________
+---
 
 ## Behaviour
 
@@ -31,7 +24,7 @@ When `core.defaultGroups` is non-empty, module rewrites `users.users` entries so
 
 This means module appends shared groups after any user-specific group configuration instead of replacing it.
 
-______________________________________________________________________
+---
 
 ## Usage Example
 
@@ -45,7 +38,7 @@ ______________________________________________________________________
 }
 ```
 
-______________________________________________________________________
+---
 
 ## Operational Notes
 

--- a/docs/src/modules/nixos/core/locale.md
+++ b/docs/src/modules/nixos/core/locale.md
@@ -2,40 +2,21 @@
 
 Sets shared timezone and locale defaults.
 
-- **Entry point**: `modules/nixos/core/locale.nix`
+- **Entry point**: [locale.nix](../../../../../modules/nixos/core/locale.nix)
 
-______________________________________________________________________
+---
 
 ## Overview
 
 This module provides opinionated regional defaults for timezone and locale. It sets Australia/Sydney timezone and enables Australian and US English UTF-8 locales.
 
-______________________________________________________________________
+---
 
 ## Options
 
-### `core.locale.enable`
+{{#include ../../../../generated/core-locale-options.md}}
 
-| | |
-|---|---|
-| Type | `bool` |
-| Default | `true` |
-
-Enable locale baseline configuration.
-
-______________________________________________________________________
-
-## Behaviour
-
-When enabled, module sets:
-
-- `time.timeZone = "Australia/Sydney"`,
-- `i18n.defaultLocale = "en_AU.UTF-8"`, and
-- `i18n.supportedLocales = [ "en_AU.UTF-8/UTF-8" "en_US.UTF-8/UTF-8" ]`.
-
-All values use `mkDefault`, so host-specific configuration can still override them.
-
-______________________________________________________________________
+---
 
 ## Usage Example
 
@@ -45,7 +26,7 @@ ______________________________________________________________________
 }
 ```
 
-______________________________________________________________________
+---
 
 ## Operational Notes
 

--- a/docs/src/modules/nixos/core/nix.md
+++ b/docs/src/modules/nixos/core/nix.md
@@ -2,9 +2,9 @@
 
 Defines shared Nix daemon, cache, and registry defaults.
 
-- **Entry point**: `modules/nixos/core/nix.nix`
+- **Entry point**: [nix.nix](../../../../../modules/nixos/core/nix.nix)
 
-______________________________________________________________________
+---
 
 ## Overview
 
@@ -12,13 +12,13 @@ This module establishes global Nix configuration for hosts in this flake. It set
 
 It also provisions cache push secret and `attic-watch-store` service for automatic uploads to remote Attic cache.
 
-______________________________________________________________________
+---
 
 ## Options
 
 This module does not define `core.*` options. It applies shared baseline configuration directly.
 
-______________________________________________________________________
+---
 
 ## Behaviour
 
@@ -35,7 +35,7 @@ Module configures:
 
 It also enables `services.angrr` to retain recent system profiles and creates `systemd.services.attic-watch-store` that waits for `network-online.target`, restarts on failure, logs into Attic with SOPS-managed `CACHE_PUSH_KEY`, and watches store for uploads.
 
-______________________________________________________________________
+---
 
 ## Operational Notes
 

--- a/docs/src/modules/nixos/core/openssh.md
+++ b/docs/src/modules/nixos/core/openssh.md
@@ -2,9 +2,9 @@
 
 Configures opinionated SSH server and client defaults.
 
-- **Entry point**: `modules/nixos/core/openssh.nix`
+- **Entry point**: [openssh.nix](../../../../../modules/nixos/core/openssh.nix)
 
-______________________________________________________________________
+---
 
 ## Overview
 
@@ -12,20 +12,13 @@ This module enables OpenSSH with ed25519-only host keys, disables password authe
 
 It also wires SOPS-managed host private key into `sshd` and publishes matching public key under `/etc/ssh/ssh_host_ed25519_key.pub`.
 
-______________________________________________________________________
+---
 
 ## Options
 
-### `core.openssh.enable`
+{{#include ../../../../generated/core-openssh-options.md}}
 
-| | |
-|---|---|
-| Type | `bool` |
-| Default | `true` |
-
-Enable opinionated OpenSSH server and client configuration.
-
-______________________________________________________________________
+---
 
 ## Behaviour
 
@@ -44,7 +37,7 @@ When enabled, module:
 
 Client configuration also restricts host key algorithms and accepted public key types to `ssh-ed25519`.
 
-______________________________________________________________________
+---
 
 ## Usage Example
 
@@ -54,7 +47,7 @@ ______________________________________________________________________
 }
 ```
 
-______________________________________________________________________
+---
 
 ## Operational Notes
 

--- a/docs/src/modules/nixos/core/printing.md
+++ b/docs/src/modules/nixos/core/printing.md
@@ -2,9 +2,9 @@
 
 Enables shared printer support for workstation-class NixOS hosts.
 
-- **Entry point**: `modules/nixos/core/printing.nix`
+- **Entry point**: [printing.nix](../../../../../modules/nixos/core/printing.nix)
 
-______________________________________________________________________
+---
 
 ## Overview
 
@@ -12,20 +12,13 @@ This module enables CUPS printing support on non-server, non-virtual hosts and i
 
 When active, it turns on `services.printing`, adds HP and Gutenprint drivers, and includes Brother MFC-L3770CDW driver packages.
 
-______________________________________________________________________
+---
 
 ## Options
 
-### `core.printing.enable`
+{{#include ../../../../generated/core-printing-options.md}}
 
-| | |
-|---|---|
-| Type | `bool` |
-| Default | `config.host.device.role != "server" && !config.host.device.isVirtual` |
-
-Enable printing support. Default keeps printing off for servers and virtual machines.
-
-______________________________________________________________________
+---
 
 ## Behaviour
 
@@ -35,7 +28,7 @@ When both `config.core.enable` and `core.printing.enable` are `true`, module:
 - installs printer drivers from `pkgs.hplip`, `pkgs.gutenprint`, `pkgs.gutenprint-bin`, `pkgs.cups-filters`, `pkgs.mfcl3770cdwlpr`, and `pkgs.mfcl3770cdwcupswrapper`, and
 - adds `lp` to `core.defaultGroups`.
 
-______________________________________________________________________
+---
 
 ## Usage Example
 
@@ -45,7 +38,7 @@ ______________________________________________________________________
 }
 ```
 
-______________________________________________________________________
+---
 
 ## Operational Notes
 

--- a/docs/src/modules/nixos/core/remote.md
+++ b/docs/src/modules/nixos/core/remote.md
@@ -2,60 +2,26 @@
 
 Provides optional remote desktop and game-streaming capabilities for desktop hosts.
 
-- **Entry point**: `modules/nixos/core/remote.nix`
+- **Entry point**: [remote.nix](../../../../../modules/nixos/core/remote.nix)
 
-______________________________________________________________________
+---
 
 ## Overview
 
 This module exposes `core.remote` with two independent sub-features:
 
-| Sub-feature | Implementation | Purpose |
-|---|---|---|
-| Remote Desktop | xrdp | Full desktop access over RDP |
-| Streaming | Sunshine | Low-latency game or desktop streaming |
+| Sub-feature    | Implementation | Purpose                               |
+| -------------- | -------------- | ------------------------------------- |
+| Remote Desktop | xrdp           | Full desktop access over RDP          |
+| Streaming      | Sunshine       | Low-latency game or desktop streaming |
 
-______________________________________________________________________
+---
 
 ## Options
 
-### `core.remote.enable`
+{{#include ../../../../generated/core-remote-options.md}}
 
-| | |
-|---|---|
-| Type | `bool` |
-| Default | disabled |
-
-Master switch. Nothing in this module activates unless this is `true`.
-
-### `core.remote.remoteDesktop.enable`
-
-| | |
-|---|---|
-| Type | `bool` |
-| Default | disabled |
-
-Enable xrdp-based remote desktop access.
-
-### `core.remote.remoteDesktop.startCommand`
-
-| | |
-|---|---|
-| Type | `string` |
-| Default | `"gnome-session"` |
-
-Command xrdp uses as `defaultWindowManager`.
-
-### `core.remote.streaming.enable`
-
-| | |
-|---|---|
-| Type | `bool` |
-| Default | disabled |
-
-Enable Sunshine streaming server.
-
-______________________________________________________________________
+---
 
 ## Behaviour
 
@@ -65,7 +31,7 @@ When `core.remote.enable = true`:
 - `streaming.enable` turns on `services.sunshine`, enables auto-start, opens firewall, and sets `capSysAdmin = true`.
 - if Home Manager is present, streaming also persists `.config/sunshine` through shared Home Manager module.
 
-______________________________________________________________________
+---
 
 ## Hyprland Integration
 
@@ -91,12 +57,12 @@ Home Manager module uses Lua-safe equivalents:
 
 For hyprlang mode, the old string forms (`exec-once`, `monitor = "HEADLESS-2,disable"`) are used unchanged.
 
-| Application | Behaviour |
-|---|---|
-| **Shared Desktop** | Enables `HEADLESS-2` at client resolution and leaves physical monitors active. |
+| Application           | Behaviour                                                                                                                                                                                  |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Shared Desktop**    | Enables `HEADLESS-2` at client resolution and leaves physical monitors active.                                                                                                             |
 | **Exclusive Desktop** | Enables `HEADLESS-2`, saves active physical monitor state to `$XDG_STATE_HOME/hyprland-disabled-monitors-pre-sunshine.json`, disables physical monitors, then restores them on disconnect. |
 
-______________________________________________________________________
+---
 
 ## Usage Examples
 
@@ -125,7 +91,7 @@ ______________________________________________________________________
 }
 ```
 
-______________________________________________________________________
+---
 
 ## Operational Notes
 

--- a/docs/src/modules/nixos/core/security.md
+++ b/docs/src/modules/nixos/core/security.md
@@ -2,37 +2,21 @@
 
 Applies shared host security defaults.
 
-- **Entry point**: `modules/nixos/core/security.nix`
+- **Entry point**: [security.nix](../../../../../modules/nixos/core/security.nix)
 
-______________________________________________________________________
+---
 
 ## Overview
 
 This module enables baseline security features such as `sudo-rs`, TPM2 support, Polkit, kernel protection flags, and open-file limits for users.
 
-______________________________________________________________________
+---
 
 ## Options
 
-### `core.security.enable`
+{{#include ../../../../generated/core-security-options.md}}
 
-| | |
-|---|---|
-| Type | `bool` |
-| Default | `true` |
-
-Enable shared security baseline.
-
-### `core.security.userLimit`
-
-| | |
-|---|---|
-| Type | `unsigned integer` |
-| Default | `32768` |
-
-Maximum number of open files per user. Applied to PAM login limits and user systemd default limit.
-
-______________________________________________________________________
+---
 
 ## Behaviour
 
@@ -46,7 +30,7 @@ When enabled, module:
 - sets `systemd.user.extraConfig = "DefaultLimitNOFILE=<limit>"`, and
 - sets kernel sysctl `fs.file-max = 65536`.
 
-______________________________________________________________________
+---
 
 ## Usage Example
 
@@ -59,7 +43,7 @@ ______________________________________________________________________
 }
 ```
 
-______________________________________________________________________
+---
 
 ## Operational Notes
 

--- a/docs/src/modules/nixos/core/sops.md
+++ b/docs/src/modules/nixos/core/sops.md
@@ -2,37 +2,21 @@
 
 Configures shared SOPS and age decryption defaults.
 
-- **Entry point**: `modules/nixos/core/sops.nix`
+- **Entry point**: [sops.nix](../../../../../modules/nixos/core/sops.nix)
 
-______________________________________________________________________
+---
 
 ## Overview
 
 This module imports `sops-nix`, sets host default secrets file, derives age SSH key paths from persisted host SSH keys, and declares managed SSH private key secret for OpenSSH.
 
-______________________________________________________________________
+---
 
 ## Options
 
-### `core.sops.enable`
+{{#include ../../../../generated/core-sops-options.md}}
 
-| | |
-|---|---|
-| Type | `bool` |
-| Default | `config.core.enable` |
-
-Enable automatic SOPS configuration.
-
-### `core.sops.hostSecretsFile`
-
-| | |
-|---|---|
-| Type | `path` |
-| Default | `"${hostDirectory}/secrets.yaml"` |
-
-Path to host-specific SOPS secrets file inside flake.
-
-______________________________________________________________________
+---
 
 ## Behaviour
 
@@ -43,7 +27,7 @@ When enabled, module:
 - builds `sops.age.sshKeyPaths` from persisted host SSH key path first, then appends any configured ed25519 OpenSSH host keys, and
 - declares `sops.secrets.SSH_PRIVATE_KEY` at `/etc/ssh/ssh_host_ed25519_key` with `sshd.service` restart hook.
 
-______________________________________________________________________
+---
 
 ## Usage Example
 
@@ -53,7 +37,7 @@ ______________________________________________________________________
 }
 ```
 
-______________________________________________________________________
+---
 
 ## Operational Notes
 

--- a/docs/src/modules/nixos/core/stylix.md
+++ b/docs/src/modules/nixos/core/stylix.md
@@ -2,28 +2,21 @@
 
 Applies shared system theme defaults with Stylix.
 
-- **Entry point**: `modules/nixos/core/stylix.nix`
+- **Entry point**: [stylix.nix](../../../../../modules/nixos/core/stylix.nix)
 
-______________________________________________________________________
+---
 
 ## Overview
 
 This module imports Stylix and enables dark Tokyo Night theming on non-headless hosts by default.
 
-______________________________________________________________________
+---
 
 ## Options
 
-### `core.stylix.enable`
+{{#include ../../../../generated/core-stylix-options.md}}
 
-| | |
-|---|---|
-| Type | `bool` |
-| Default | `!config.host.device.isHeadless` |
-
-Enable Stylix configuration. Default disables theming on headless hosts.
-
-______________________________________________________________________
+---
 
 ## Behaviour
 
@@ -34,7 +27,7 @@ When enabled, module:
 - sets `stylix.polarity = "dark"`, and
 - uses Tokyo Night dark Base16 scheme from `tinted-schemes` input.
 
-______________________________________________________________________
+---
 
 ## Usage Example
 
@@ -44,7 +37,7 @@ ______________________________________________________________________
 }
 ```
 
-______________________________________________________________________
+---
 
 ## Operational Notes
 

--- a/docs/src/modules/nixos/core/virtualisation.md
+++ b/docs/src/modules/nixos/core/virtualisation.md
@@ -2,9 +2,9 @@
 
 Configures libvirt, VFIO passthrough, bridge networking, and guest isolation helpers.
 
-- **Entry point**: `modules/nixos/core/virtualisation.nix`
+- **Entry point**: [virtualisation.nix](../../../../../modules/nixos/core/virtualisation.nix)
 
-______________________________________________________________________
+---
 
 ## Overview
 
@@ -12,83 +12,13 @@ This module enables libvirt with QEMU, VFIO GPU passthrough, Looking Glass share
 
 It also generates helper scripts that change `AllowedCPUs` on host slices while selected guests run, detach and reattach passthrough GPUs for `-single` guests, and block host sleep while libvirt domains are active.
 
-______________________________________________________________________
+---
 
 ## Options
 
-### `core.virtualisation.enable`
+{{#include ../../../../generated/core-virtualisation-options.md}}
 
-| | |
-|---|---|
-| Type | `bool` |
-| Default | disabled |
-
-Master switch for virtualisation support.
-
-### `core.virtualisation.vmUsers`
-
-| | |
-|---|---|
-| Type | `list of string` |
-| Default | `[]` |
-
-Users that receive `kvm` and `libvirtd` group membership for VM management.
-
-### `core.virtualisation.isolatedGuests`
-
-| | |
-|---|---|
-| Type | `list of string` |
-| Default | `[ "win11" "win11-gaming" ]` |
-
-Guest names that receive generated libvirt hook directories for CPU isolation helpers. Each guest also gets `-single` hook variants that add GPU detach and attach helpers.
-
-### `core.virtualisation.bridgeInterface`
-
-| | |
-|---|---|
-| Type | `string` |
-| Default | `"br0"` |
-
-Bridge interface exposed to libvirt guests.
-
-### `core.virtualisation.externalInterface`
-
-| | |
-|---|---|
-| Type | `string` |
-| Default | `"eth0"` |
-
-Physical interface attached to `core.virtualisation.bridgeInterface`.
-
-### `core.virtualisation.cpuCores`
-
-| | |
-|---|---|
-| Type | `int >= 4` |
-| Default | `24` |
-
-Total CPU core or thread count used by isolation helpers.
-
-### `core.virtualisation.gpu.video`
-
-| | |
-|---|---|
-| Type | `string` |
-| Default | `"10de:1b06"` |
-
-PCI ID for passthrough GPU video device.
-
-### `core.virtualisation.gpu.audio`
-
-| | |
-|---|---|
-| Type | `string` |
-| Default | `"10de:1bef"` |
-
-PCI ID for passthrough GPU audio device.
-
-______________________________________________________________________
+---
 
 ## Behaviour
 
@@ -106,7 +36,7 @@ When enabled, module:
 
 Module also persists libvirt and swtpm state under `host.persistence.directories`.
 
-______________________________________________________________________
+---
 
 ## Isolation and Hook Helpers
 
@@ -119,7 +49,7 @@ For each guest in `core.virtualisation.isolatedGuests`, module creates libvirt h
 
 It also creates `libvirt-nosleep@<guest>` service that uses `systemd-inhibit` to block sleep while guest is running.
 
-______________________________________________________________________
+---
 
 ## Firmware and Persistence
 
@@ -133,7 +63,7 @@ Persisted paths include:
 - `/var/lib/libvirt/secrets`
 - `/var/lib/swtpm-localca`
 
-______________________________________________________________________
+---
 
 ## Usage Example
 
@@ -155,7 +85,7 @@ ______________________________________________________________________
 }
 ```
 
-______________________________________________________________________
+---
 
 ## Operational Notes
 

--- a/docs/src/modules/nixos/core/wsl.md
+++ b/docs/src/modules/nixos/core/wsl.md
@@ -2,37 +2,21 @@
 
 Adds Windows Subsystem for Linux specific integration and fixes.
 
-- **Entry point**: `modules/nixos/core/wsl.nix`
+- **Entry point**: [wsl.nix](../../../../../modules/nixos/core/wsl.nix)
 
-______________________________________________________________________
+---
 
 ## Overview
 
 This module configures WSL-focused defaults such as default user, Windows interop, graphics library paths, `nix-ld`, and Start Menu launcher syncing.
 
-______________________________________________________________________
+---
 
 ## Options
 
-### `core.wsl.enable`
+{{#include ../../../../generated/core-wsl-options.md}}
 
-| | |
-|---|---|
-| Type | `bool` |
-| Default | disabled |
-
-Enable WSL-specific configuration.
-
-### `core.wsl.user`
-
-| | |
-|---|---|
-| Type | `string` |
-| Default | none |
-
-Default user used for WSL integration.
-
-______________________________________________________________________
+---
 
 ## Behaviour
 
@@ -54,7 +38,7 @@ If `wsl` module exists in option tree, module also:
 - exposes `dirname`, `readlink`, and `uname` through `wsl.extraBin` for VS Code Remote WSL compatibility, and
 - copies per-user Home Manager `applications` and `icons` into `/usr/share` during activation so launchers appear in Windows Start Menu.
 
-______________________________________________________________________
+---
 
 ## Usage Example
 
@@ -67,7 +51,7 @@ ______________________________________________________________________
 }
 ```
 
-______________________________________________________________________
+---
 
 ## Operational Notes
 

--- a/docs/src/modules/nixos/server/dashboard.md
+++ b/docs/src/modules/nixos/server/dashboard.md
@@ -10,14 +10,9 @@ The dashboard module integrates with [Dashy](https://dashy.to/) and collects das
 
 - `modules/nixos/server/dashboard.nix`
 
-## Special Options and Behaviors
+## Options
 
-The module provides options under `server.dashboard` to define the section for each server:
-
-- **`server.dashboard.name`**: The name of the section in the dashboard, defaulting to the capitalized hostname.
-- **`server.dashboard.icon`**: An optional icon for the section.
-- **`server.dashboard.items`**: A set of dashboard items (with `title`, `icon`, and `url`) to be displayed.
-- **`server.dashboard.displayData`**: Arbitrary JSON data to be passed to the dashboard configuration.
+{{#include ../../../../generated/server-dashboard-options.md}}
 
 ## Example Usage
 

--- a/docs/src/modules/nixos/server/database.md
+++ b/docs/src/modules/nixos/server/database.md
@@ -4,10 +4,10 @@ The database submodule provides a managed interface for PostgreSQL and Redis acr
 
 The module is implemented across several files in `modules/nixos/server/database/`:
 
-- `default.nix`: Core options and connection management.
-- `postgres.nix`: PostgreSQL-specific provisioning and secrets.
-- `redis.nix`: Redis-specific ID mappings and security.
-- `guardian.nix`: Lifecycle synchronization and the [IO Guardian](../../../components/io_guardian.md).
+- [default.nix](../../../../../modules/nixos/server/database/default.nix): Core options and connection management.
+- [postgres.nix](../../../../../modules/nixos/server/database/postgres.nix): PostgreSQL-specific provisioning and secrets.
+- [redis.nix](../../../../../modules/nixos/server/database/redis.nix): Redis-specific ID mappings and security.
+- [guardian.nix](../../../../../modules/nixos/server/database/guardian.nix): Lifecycle synchronization and the [IO Guardian](../../../components/io_guardian.md).
 
 ## Purpose
 

--- a/docs/src/modules/nixos/server/default.md
+++ b/docs/src/modules/nixos/server/default.md
@@ -10,6 +10,10 @@ The primary purpose of this module is to establish a shared environment for serv
 
 - `modules/nixos/server/default.nix`
 
+## Options
+
+{{#include ../../../../generated/server-options.md}}
+
 ## Special Options and Behaviors
 
 The main configuration entry point is `server.enable`. Once enabled, it sets up the server-specific baseline:

--- a/docs/src/modules/nixos/server/distributed_builds.md
+++ b/docs/src/modules/nixos/server/distributed_builds.md
@@ -10,12 +10,9 @@ The distributed builds module allows for distributed building of Nix derivations
 
 - `modules/nixos/server/distributed-builds.nix`
 
-## Special Options and Behaviors
+## Options
 
-The module provides options under `server.distributedBuilder`:
-
-- **`server.distributedBuilder.builderUser`**: The user to use when connecting to remote build daemons (default: `builder`).
-- **`server.distributedBuilder.builders`**: A list of hostnames of remote build daemons to connect to for distributed builds.
+{{#include ../../../../generated/server-distributed-builds-options.md}}
 
 ## Example Usage
 

--- a/docs/src/modules/nixos/server/network.md
+++ b/docs/src/modules/nixos/server/network.md
@@ -10,15 +10,9 @@ The network module coordinates network subnet definitions and firewall rules, al
 
 - `modules/nixos/server/network.nix`
 
-## Special Options and Behaviors
+## Options
 
-The main configuration options are under `server.network`:
-
-- **`server.network.subnets`**: A list of subnet definitions, each with:
-  - `dns`: The DNS server for the subnet.
-  - `domain`: The domain name for the subnet.
-  - `ipv4`, `ipv6`: Configuration options (like CIDR and ARPA) for the subnet's IP range.
-- **`server.network.openPortsForSubnet`**: Defines TCP and UDP ports to be opened on the firewall for each defined subnet.
+{{#include ../../../../generated/server-network-options.md}}
 
 ## Example Usage
 

--- a/docs/src/modules/nixos/server/proxy.md
+++ b/docs/src/modules/nixos/server/proxy.md
@@ -6,32 +6,9 @@ The Proxy submodule provides a unified interface for exposing internal services 
 
 This module abstracts the complexity of reverse proxying by allowing services to define their proxy requirements within their own module configuration. It automatically coordinates between backend hosts and the primary IO host to ensure ports are open and traffic is correctly routed.
 
-## Entry Points
+## Options
 
-The primary configuration is managed through:
-
-- `server.proxy.domain`: The root domain for all services (e.g., `example.com`).
-- `server.proxy.virtualHosts`: An attribute set of service configurations.
-
-## Key Options and Behaviors
-
-### Global Options
-
-- **`server.proxy.domain`**: Defines the base domain. All virtual hosts default to `<name>.<domain>` unless overridden.
-- **`server.proxy.kanidmContexts`**: Defines shared OAuth2 configurations that can be reused across multiple virtual hosts.
-  - **`scopes`**: Default scopes are `["openid" "email" "profile" "groups"]`.
-  - **`tokenLifetime`**: Default lifetime is `3600` seconds.
-
-### Virtual Host Options
-
-- **`aliases`**: A list of additional hostnames (relative to `server.proxy.domain`) that route to this service.
-- **`public`**: If true, the service is added to the Cloudflared tunnel ingress for public access.
-- **`ports`**: List of ports to open on the backend host to allow traffic from the IO primary host.
-- **`kanidm`**: Configures OAuth2 protection. If enabled, the module generates Caddy security blocks and handles Kanidm client provisioning.
-  - **`bypassPaths`**: List of path patterns (e.g., `/api/*`) that should bypass authentication.
-  - **`allowGroups`**: List of groups allowed access. **Note**: This cannot be empty if Kanidm is enabled.
-- **`l4`**: Configures Layer 4 forwarding using the Caddy L4 plugin. This opens both TCP and UDP ports on the IO primary host.
-- **`extraConfig`**: Injected directly into the Caddy `handle` block. `localhost` references are automatically replaced with the backend host's address.
+{{#include ../../../../generated/server-proxy-options.md}}
 
 ## Per-Module Examples
 

--- a/docs/src/modules/nixos/server/ssh.md
+++ b/docs/src/modules/nixos/server/ssh.md
@@ -6,7 +6,9 @@ The Server SSH module provides a rich interactive environment for root users upo
 
 The SSH submodule enhances administrative access by providing a session-only environment tailored for server management. It removes the need for manual setup of common tools and aliases by automatically entering a pre-configured `nix-shell` when a root user logs in interactively over SSH.
 
-## Key Options and Behaviors
+## Options
+
+{{#include ../../../../generated/server-ssh-options.md}}
 
 ### Auto-entry Logic (`ssh/default.nix`)
 

--- a/docs/src/modules/nixos/services/ai-agent.md
+++ b/docs/src/modules/nixos/services/ai-agent.md
@@ -1,0 +1,1 @@
+## AI Agent

--- a/docs/src/modules/nixos/services/ai-agent.md
+++ b/docs/src/modules/nixos/services/ai-agent.md
@@ -1,1 +1,0 @@
-## AI Agent

--- a/docs/src/modules/nixos/services/ai_agent.md
+++ b/docs/src/modules/nixos/services/ai_agent.md
@@ -5,9 +5,9 @@ Autonomous AI Agent service powered by Hermes, providing intelligent task automa
 - **Entry point**: `modules/nixos/services/ai-agent.nix`
 - **Upstream**: [Hermes Agent](https://hermes-agent.nousresearch.com/)
 
-### Special Options
+### Options
 
-- `services.ai-agent.enable`: Enable the autonomous AI Agent service.
+{{#include ../../../../generated/services-ai-agent-options.md}}
 
 ### Secrets Management
 

--- a/docs/src/modules/nixos/services/default.md
+++ b/docs/src/modules/nixos/services/default.md
@@ -1,3 +1,5 @@
 # NixOS Services
 
 This section documents the custom NixOS service modules available in this configuration. These modules provide specialised integrations and monitoring capabilities.
+
+Nested service modules emit generated fragments such as `services-ai-agent-options.md`.

--- a/docs/src/modules/nixos/services/huntress.md
+++ b/docs/src/modules/nixos/services/huntress.md
@@ -5,10 +5,9 @@ Managed EDR (Endpoint Detection and Response) platform that protects systems by 
 - **Entry point**: `modules/nixos/services/huntress.nix`
 - **Upstream**: [Huntress Managed EDR](https://www.huntress.com/platform/managed-edr)
 
-### Special Options
+### Options
 
-- `services.huntress.accountKeyFile`: Path to a file containing the Huntress account key.
-- `services.huntress.organisationKeyFile`: Path to a file containing the Huntress organisation key.
+{{#include ../../../../generated/services-huntress-options.md}}
 
 ### Usage Example
 

--- a/docs/src/modules/nixos/services/mcpo.md
+++ b/docs/src/modules/nixos/services/mcpo.md
@@ -5,12 +5,9 @@ Orchestrates Model Context Protocol (MCP) servers, providing a centralized way t
 - **Entry point**: `modules/nixos/services/mcpo.nix`
 - **Upstream**: [MCPO GitHub Repository](https://github.com/open-webui/mcpo)
 
-### Special Options
+### Options
 
-- `services.mcpo.configuration`: An attribute set defining the MCP servers to orchestrate.
-- `services.mcpo.apiTokenFile`: Optional path to a file containing an API token for the service.
-- `services.mcpo.extraPackages`: Additional packages to include in the service's `PATH`.
-- `services.mcpo.helpers`: Read-only attribute set of helper functions for common server types (e.g., `npxServer`, `uvxServer`).
+{{#include ../../../../generated/services-mcpo-options.md}}
 
 ### Usage Example
 

--- a/docs/src/modules/nixos/services/metrics.md
+++ b/docs/src/modules/nixos/services/metrics.md
@@ -5,13 +5,9 @@ Comprehensive metrics collection and integration with Home Assistant via `hacomp
 - **Entry point**: `modules/nixos/services/metrics.nix`
 - **Upstream**: [Hacompanion GitHub Repository](https://github.com/tobias-kuendig/hacompanion)
 
-### Special Options
+### Options
 
-- `services.metrics.hacompanion.enable`: Enable the Home Assistant Companion service.
-- `services.metrics.hacompanion.sensor.<name>.enable`: Enable specific built-in sensors (e.g., `cpu_temp`, `memory`, `uptime`).
-- `services.metrics.hacompanion.script`: Define custom scripts to expose as sensors or switches in Home Assistant.
-- `services.metrics.hacompanion.storage`: Configure monitoring for storage devices and ZFS pools.
-- `services.metrics.upgradeStatus.enable`: Enable a specialized sensor for tracking NixOS upgrade status.
+{{#include ../../../../generated/services-metrics-options.md}}
 
 ### Usage Example
 

--- a/docs/src/modules/nixos/services/tailscale.md
+++ b/docs/src/modules/nixos/services/tailscale.md
@@ -3,11 +3,10 @@
 Extensions to the standard NixOS Tailscale module, providing easier tag management.
 
 - **Entry point**: `modules/nixos/services/tailscale.nix`
-- **Upstream**: [Tailscale Tags Documentation](https://tailscale.com/kb/1018/tags/)
 
-### Special Options
+### Options
 
-- `services.tailscale.tags`: A list of tags to advertise for this device. These tags are automatically prefixed with `tag:` when passed to `tailscale up`.
+{{#include ../../../../generated/services-tailscale-options.md}}
 
 ### Usage Example
 

--- a/lib/builders/home/mkHomeManager.nix
+++ b/lib/builders/home/mkHomeManager.nix
@@ -13,6 +13,7 @@ self.inputs.home-manager.lib.homeManagerConfiguration {
   extraSpecialArgs = {
     inherit self;
     inherit (self) inputs outputs;
+    importExternals = true;
   };
 
   modules = [

--- a/lib/builders/mkSystem.nix
+++ b/lib/builders/mkSystem.nix
@@ -89,6 +89,7 @@ nixosSystem rec {
           extraSpecialArgs = {
             inherit self;
             inherit (self) inputs outputs;
+            importExternals = true;
           };
 
           sharedModules = optionals (!config.stylix.enable) config.stylix.homeManagerIntegration.module;

--- a/modules/home-manager/audio.nix
+++ b/modules/home-manager/audio.nix
@@ -11,6 +11,7 @@ let
     filter
     hasPrefix
     length
+    literalExpression
     mapAttrsToList
     mkEnableOption
     mkIf
@@ -38,6 +39,7 @@ in
   options.core.audio = {
     enable = mkEnableOption "audio module" // {
       default = osConfig != null && !osConfig.host.device.isHeadless;
+      defaultText = literalExpression "osConfig != null && !osConfig.host.device.isHeadless";
     };
 
     disabledDevices = mkOption {

--- a/modules/home-manager/core/theme.nix
+++ b/modules/home-manager/core/theme.nix
@@ -7,10 +7,11 @@
 }:
 let
   inherit (lib)
+    getExe'
     hasAttr
+    literalExpression
     mkEnableOption
     mkIf
-    getExe'
     ;
 
   cfg = config.core.theme;
@@ -19,6 +20,7 @@ in
   options.core.theme = {
     enable = mkEnableOption "theming" // {
       default = osConfig != null && hasAttr "stylix" osConfig && osConfig.stylix.enable;
+      defaultText = literalExpression "osConfig != null && hasAttr \"stylix\" osConfig && osConfig.stylix.enable";
     };
   };
 

--- a/modules/home-manager/core/uwsm.nix
+++ b/modules/home-manager/core/uwsm.nix
@@ -8,6 +8,7 @@ let
   inherit (lib)
     flatten
     listToAttrs
+    literalExpression
     mapAttrsToList
     mkEnableOption
     mkIf
@@ -23,6 +24,7 @@ in
   options.core.uwsm = {
     enable = mkEnableOption "uwsm" // {
       default = osConfig != null && osConfig.programs.uwsm.enable;
+      defaultText = literalExpression "osConfig != null && osConfig.programs.uwsm.enable";
     };
 
     sliceAllocation = mkOption {

--- a/modules/home-manager/programs/list-ephemeral.nix
+++ b/modules/home-manager/programs/list-ephemeral.nix
@@ -115,6 +115,7 @@ in
   options.programs.list-ephemeral = {
     enable = mkEnableOption "list-ephemeral helper" // {
       default = hostPersistEnabled || config.user.persistence.enable;
+      defaultText = lib.literalExpression "hostPersistEnabled || config.user.persistence.enable";
     };
 
     extraExcludes = mkOption {

--- a/modules/home-manager/purpose/default.nix
+++ b/modules/home-manager/purpose/default.nix
@@ -1,7 +1,7 @@
 { lib, config, ... }:
 with lib;
 let
-  cfg = config.purposes;
+  cfg = config.purpose;
 in
 {
   imports = [

--- a/modules/home-manager/purpose/development/editors/ai/skills/code-style-nix/SKILL.md
+++ b/modules/home-manager/purpose/development/editors/ai/skills/code-style-nix/SKILL.md
@@ -12,11 +12,11 @@ description: Write Nix code using repo conventions
 
 ## Naming Conventions
 
-| Context | Convention | Example |
+| Context               | Convention | Example                          |
 | --------------------- | ---------- | -------------------------------- |
 | Files and directories | kebab-case | `my-module.nix`, `home-manager/` |
-| Nix attributes | camelCase | `myOption`, `enableFeature` |
-| Option paths | camelCase | `services.myService.enable` |
+| Nix attributes        | camelCase  | `myOption`, `enableFeature`      |
+| Option paths          | camelCase  | `services.myService.enable`      |
 
 ## Comments
 

--- a/modules/home-manager/purpose/development/editors/ai/skills/conventional-commits/SKILL.md
+++ b/modules/home-manager/purpose/development/editors/ai/skills/conventional-commits/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: conventional-commits
-description: 'Write and review Conventional Commits commit messages (v1.0.0) for semantic versioning and changelogs. Use when drafting git commit messages, PR titles, release notes, or enforcing conventional commit format like `type(scope): subject`, `BREAKING CHANGE`, footers, and `revert`.'
+description: "Write and review Conventional Commits commit messages (v1.0.0) for semantic versioning and changelogs. Use when drafting git commit messages, PR titles, release notes, or enforcing conventional commit format like `type(scope): subject`, `BREAKING CHANGE`, footers, and `revert`."
 ---
 
 # Conventional Commits (v1.0.0)

--- a/modules/home-manager/purpose/development/editors/ai/skills/jujutsu/SKILL.md
+++ b/modules/home-manager/purpose/development/editors/ai/skills/jujutsu/SKILL.md
@@ -16,21 +16,21 @@ Git-compatible VCS for concurrent work and easier history editing.
 
 ## Key Commands
 
-| Command | Description |
-| -------------------------- | ----------------------------------------- |
-| `jj st` | Show working copy status |
-| `jj log` | Show change log |
-| `jj diff` | Show working copy changes |
-| `jj new` | Create new change |
-| `jj desc` | Edit change description |
-| `jj squash` | Move changes to parent |
-| `jj split` | Split current change |
-| `jj rebase -s src -d dest` | Rebase changes |
-| `jj absorb` | Move changes into mutable stack |
-| `jj bisect` | Find bad revision by bisection |
-| `jj fix` | Update files with formatter fixes |
-| `jj sign` | Cryptographically sign revision |
-| `jj metaedit` | Edit metadata without changing content |
+| Command                    | Description                            |
+| -------------------------- | -------------------------------------- |
+| `jj st`                    | Show working copy status               |
+| `jj log`                   | Show change log                        |
+| `jj diff`                  | Show working copy changes              |
+| `jj new`                   | Create new change                      |
+| `jj desc`                  | Edit change description                |
+| `jj squash`                | Move changes to parent                 |
+| `jj split`                 | Split current change                   |
+| `jj rebase -s src -d dest` | Rebase changes                         |
+| `jj absorb`                | Move changes into mutable stack        |
+| `jj bisect`                | Find bad revision by bisection         |
+| `jj fix`                   | Update files with formatter fixes      |
+| `jj sign`                  | Cryptographically sign revision        |
+| `jj metaedit`              | Edit metadata without changing content |
 
 ## Project Setup
 
@@ -78,15 +78,15 @@ jj resolve               # Interactive conflict resolution
 
 **Parent/child operators:**
 
-| Syntax | Meaning | Example |
+| Syntax | Meaning          | Example              |
 | ------ | ---------------- | -------------------- |
-| `@-` | Parent of @ | `jj diff -r @-` |
-| `@--` | Grandparent | `jj log -r @--` |
-| `x-` | Parent of x | `jj diff -r abc123-` |
-| `@+` | Child of @ | `jj log -r @+` |
-| `x::y` | x to y inclusive | `jj log -r main::@` |
-| `x..y` | x to y exclusive | `jj log -r main..@` |
-| `x\|y` | Union (or) | `jj log -r 'a \| b'` |
+| `@-`   | Parent of @      | `jj diff -r @-`      |
+| `@--`  | Grandparent      | `jj log -r @--`      |
+| `x-`   | Parent of x      | `jj diff -r abc123-` |
+| `@+`   | Child of @       | `jj log -r @+`       |
+| `x::y` | x to y inclusive | `jj log -r main::@`  |
+| `x..y` | x to y exclusive | `jj log -r main..@`  |
+| `x\|y` | Union (or)       | `jj log -r 'a \| b'` |
 
 **⚠️ Common mistakes:**
 

--- a/modules/home-manager/purpose/development/editors/ai/skills/systemd-hardening/SKILL.md
+++ b/modules/home-manager/purpose/development/editors/ai/skills/systemd-hardening/SKILL.md
@@ -33,17 +33,17 @@ serviceConfig = {
 
 **Why each matters:**
 
-| Option | What it prevents |
-| ----------------------- | ------------------------------------------------------------------------------------------------ |
-| `NoNewPrivileges` | Process or children gaining new privilege through setuid/setgid binaries or filesystem capabilities |
-| `ProtectClock` | Modifying system clock (only NTP daemons need this) |
-| `ProtectHostname` | Changing system hostname or NIS domain |
-| `ProtectKernelModules` | Loading or unloading kernel modules |
-| `ProtectKernelLogs` | Accessing kernel log ring buffer |
-| `ProtectKernelTunables` | Writing to `/proc/sys`, `/sys`, or similar kernel tunables |
-| `RestrictRealtime` | Acquiring real-time scheduling policies (prevents CPU starvation attacks) |
-| `RestrictSUIDSGID` | Creating setuid/setgid files |
-| `LockPersonality` | Changing execution personality (prevents running non-native binaries) |
+| Option                  | What it prevents                                                                                    |
+| ----------------------- | --------------------------------------------------------------------------------------------------- |
+| `NoNewPrivileges`       | Process or children gaining new privilege through setuid/setgid binaries or filesystem capabilities |
+| `ProtectClock`          | Modifying system clock (only NTP daemons need this)                                                 |
+| `ProtectHostname`       | Changing system hostname or NIS domain                                                              |
+| `ProtectKernelModules`  | Loading or unloading kernel modules                                                                 |
+| `ProtectKernelLogs`     | Accessing kernel log ring buffer                                                                    |
+| `ProtectKernelTunables` | Writing to `/proc/sys`, `/sys`, or similar kernel tunables                                          |
+| `RestrictRealtime`      | Acquiring real-time scheduling policies (prevents CPU starvation attacks)                           |
+| `RestrictSUIDSGID`      | Creating setuid/setgid files                                                                        |
+| `LockPersonality`       | Changing execution personality (prevents running non-native binaries)                               |
 
 ### Tier 2: Isolation (safe for most services)
 
@@ -60,14 +60,14 @@ serviceConfig = {
 };
 ```
 
-| Option | What it does | When to relax |
+| Option               | What it does                                                           | When to relax                                                                                     |
 | -------------------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| `PrivateDevices` | Hides `/dev` device nodes (only pseudo-devices remain) | Service needs raw device access (for example GPU or USB) |
-| `PrivateTmp` | Gives service its own `/tmp` and `/var/tmp` | Rarely needs relaxing |
-| `PrivateMounts` | Isolates mount namespace | Service creates mount points |
-| `ProtectHome` | Makes `/home`, `/root`, `/run/user` inaccessible | Service reads user home directories |
-| `ProtectSystem` | Makes filesystem read-only (`"strict"`) or mostly read-only (`"full"`) | Use `"full"` if service writes to `/etc`; pair `"strict"` with `ReadWritePaths` for specific dirs |
-| `RestrictNamespaces` | Blocks creating new namespaces | Service uses containers or sandboxing internally |
+| `PrivateDevices`     | Hides `/dev` device nodes (only pseudo-devices remain)                 | Service needs raw device access (for example GPU or USB)                                          |
+| `PrivateTmp`         | Gives service its own `/tmp` and `/var/tmp`                            | Rarely needs relaxing                                                                             |
+| `PrivateMounts`      | Isolates mount namespace                                               | Service creates mount points                                                                      |
+| `ProtectHome`        | Makes `/home`, `/root`, `/run/user` inaccessible                       | Service reads user home directories                                                               |
+| `ProtectSystem`      | Makes filesystem read-only (`"strict"`) or mostly read-only (`"full"`) | Use `"full"` if service writes to `/etc`; pair `"strict"` with `ReadWritePaths` for specific dirs |
+| `RestrictNamespaces` | Blocks creating new namespaces                                         | Service uses containers or sandboxing internally                                                  |
 
 **`ProtectSystem` levels:**
 
@@ -95,11 +95,11 @@ serviceConfig = {
 };
 ```
 
-| Option | What it does | When to use |
-| -------------- | --------------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| `DynamicUser` | Allocates temporary uid/gid that is released when service stops | Stateless services, no persistent file ownership needed |
-| `User`/`Group` | Run as specific pre-created user | Services needing stable uid (for example file ownership across restarts) |
-| `PrivateUsers` | Isolates user/group databases | Most services; breaks if service needs to look up other system users |
+| Option         | What it does                                                    | When to use                                                              |
+| -------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `DynamicUser`  | Allocates temporary uid/gid that is released when service stops | Stateless services, no persistent file ownership needed                  |
+| `User`/`Group` | Run as specific pre-created user                                | Services needing stable uid (for example file ownership across restarts) |
+| `PrivateUsers` | Isolates user/group databases                                   | Most services; breaks if service needs to look up other system users     |
 
 **Choosing between DynamicUser and User/Group:**
 
@@ -141,15 +141,15 @@ serviceConfig = {
 
 **Capability reference (common services):**
 
-| Capability | Purpose | Typical services |
+| Capability                  | Purpose                               | Typical services                            |
 | --------------------------- | ------------------------------------- | ------------------------------------------- |
-| `CAP_NET_BIND_SERVICE` | Bind to privileged ports (< 1024) | Web servers, DNS |
-| `CAP_CHOWN` | Change file ownership | Services managing files for multiple users |
-| `CAP_DAC_OVERRIDE` | Bypass file read/write/execute checks | Backup services, file managers |
-| `CAP_SETUID` / `CAP_SETGID` | Change process UID/GID | Services that drop privileges after startup |
-| `CAP_SYS_CHROOT` | Use `chroot(2)` | Mail servers, FTP servers |
-| `CAP_NET_RAW` | Use raw sockets | Ping, network monitoring |
-| `CAP_NET_ADMIN` | Network administration | VPN, firewall management |
+| `CAP_NET_BIND_SERVICE`      | Bind to privileged ports (< 1024)     | Web servers, DNS                            |
+| `CAP_CHOWN`                 | Change file ownership                 | Services managing files for multiple users  |
+| `CAP_DAC_OVERRIDE`          | Bypass file read/write/execute checks | Backup services, file managers              |
+| `CAP_SETUID` / `CAP_SETGID` | Change process UID/GID                | Services that drop privileges after startup |
+| `CAP_SYS_CHROOT`            | Use `chroot(2)`                       | Mail servers, FTP servers                   |
+| `CAP_NET_RAW`               | Use raw sockets                       | Ping, network monitoring                    |
+| `CAP_NET_ADMIN`             | Network administration                | VPN, firewall management                    |
 
 **SystemCallFilter sets:**
 
@@ -271,16 +271,16 @@ When hardened service fails to start, isolate which option caused failure:
 1. If service fails, check `journalctl -u myservice.service` for errors
 1. Look for common failure patterns:
 
-| Error pattern | Likely cause | Fix |
+| Error pattern                            | Likely cause                                | Fix                                                        |
 | ---------------------------------------- | ------------------------------------------- | ---------------------------------------------------------- |
-| `Permission denied` on filesystem paths | `ProtectSystem` too strict | Add `ReadWritePaths` or use `StateDirectory` |
-| `Operation not permitted` on device | `PrivateDevices = true` | Set to `false` or add specific `DeviceAllow` entries |
-| `Permission denied` on port bind | Missing `CAP_NET_BIND_SERVICE` | Add to `CapabilityBoundingSet` |
-| `Protocol not supported` / socket errors | `RestrictAddressFamilies` too restrictive | Add required `AF_*` families |
-| Segfault or JIT failure | `MemoryDenyWriteExecute = true` | Set to `false` for JIT-dependent services |
-| `Operation not permitted` on syscall | `SystemCallFilter` missing required syscall | Add syscall or filter set; use `SystemCallLog` to identify |
-| Service can't find users/groups | `PrivateUsers = true` | Set to `false` if service needs system user lookups |
-| `Failed to set hostname` | `ProtectHostname = true` | Set to `false` (rare — most services don't set hostname) |
+| `Permission denied` on filesystem paths  | `ProtectSystem` too strict                  | Add `ReadWritePaths` or use `StateDirectory`               |
+| `Operation not permitted` on device      | `PrivateDevices = true`                     | Set to `false` or add specific `DeviceAllow` entries       |
+| `Permission denied` on port bind         | Missing `CAP_NET_BIND_SERVICE`              | Add to `CapabilityBoundingSet`                             |
+| `Protocol not supported` / socket errors | `RestrictAddressFamilies` too restrictive   | Add required `AF_*` families                               |
+| Segfault or JIT failure                  | `MemoryDenyWriteExecute = true`             | Set to `false` for JIT-dependent services                  |
+| `Operation not permitted` on syscall     | `SystemCallFilter` missing required syscall | Add syscall or filter set; use `SystemCallLog` to identify |
+| Service can't find users/groups          | `PrivateUsers = true`                       | Set to `false` if service needs system user lookups        |
+| `Failed to set hostname`                 | `ProtectHostname = true`                    | Set to `false` (rare — most services don't set hostname)   |
 
 ### Using systemd-analyze security
 

--- a/modules/home-manager/purpose/development/editors/ai/skills/tmux/SKILL.md
+++ b/modules/home-manager/purpose/development/editors/ai/skills/tmux/SKILL.md
@@ -9,14 +9,14 @@ Terminal multiplexer for background jobs, output capture, and session control.
 
 ## Quick Reference
 
-| Command | Description |
+| Command                               | Description                       |
 | ------------------------------------- | --------------------------------- |
-| `tmux new -d -s name 'cmd'` | Run command in background session |
-| `tmux capture-pane -t name -p` | Capture session output |
-| `tmux send-keys -t name 'text' Enter` | Send input to session |
-| `tmux kill-session -t name` | Kill session |
-| `tmux ls` | List sessions |
-| `tmux has -t name` | Check if session exists |
+| `tmux new -d -s name 'cmd'`           | Run command in background session |
+| `tmux capture-pane -t name -p`        | Capture session output            |
+| `tmux send-keys -t name 'text' Enter` | Send input to session             |
+| `tmux kill-session -t name`           | Kill session                      |
+| `tmux ls`                             | List sessions                     |
+| `tmux has -t name`                    | Check if session exists           |
 
 ## Running Background Processes
 

--- a/modules/home-manager/purpose/development/editors/ai/skills/vhs/SKILL.md
+++ b/modules/home-manager/purpose/development/editors/ai/skills/vhs/SKILL.md
@@ -35,27 +35,27 @@ Screenshot output.png       # Capture current frame
 
 ## Commands
 
-| Command | Description |
-| --------------------------------- | ---------------- |
-| `Type "text"` | Type text |
-| `Enter`, `Tab`, `Escape`, `Space` | Press key |
-| `Ctrl+x`, `Alt+x` | Key combo |
-| `Up`, `Down`, `Left`, `Right` | Arrow keys |
-| `Sleep 1s` | Wait (`ms`, `s`) |
-| `Screenshot file.png` | Capture frame |
-| `Hide` / `Show` | Toggle visibility |
+| Command                           | Description       |
+| --------------------------------- | ----------------- |
+| `Type "text"`                     | Type text         |
+| `Enter`, `Tab`, `Escape`, `Space` | Press key         |
+| `Ctrl+x`, `Alt+x`                 | Key combo         |
+| `Up`, `Down`, `Left`, `Right`     | Arrow keys        |
+| `Sleep 1s`                        | Wait (`ms`, `s`)  |
+| `Screenshot file.png`             | Capture frame     |
+| `Hide` / `Show`                   | Toggle visibility |
 
 ## Settings
 
-| Setting | Example |
+| Setting                        | Example            |
 | ------------------------------ | ------------------ |
-| `Set Shell "bash"` | Shell to use |
-| `Set FontSize 14` | Font size |
-| `Set Width 1200` | Terminal width |
-| `Set Height 600` | Terminal height |
-| `Set Theme "Catppuccin Mocha"` | Color theme |
-| `Set Padding 20` | Window padding |
-| `Set WindowBar Colorful` | Window decorations |
+| `Set Shell "bash"`             | Shell to use       |
+| `Set FontSize 14`              | Font size          |
+| `Set Width 1200`               | Terminal width     |
+| `Set Height 600`               | Terminal height    |
+| `Set Theme "Catppuccin Mocha"` | Color theme        |
+| `Set Padding 20`               | Window padding     |
+| `Set WindowBar Colorful`       | Window decorations |
 
 ## Example: TUI Screenshot
 

--- a/modules/home-manager/purpose/development/editors/ai/skills/vhs/SKILL.md
+++ b/modules/home-manager/purpose/development/editors/ai/skills/vhs/SKILL.md
@@ -47,7 +47,7 @@ Screenshot output.png       # Capture current frame
 
 ## Settings
 
-| Setting                        | Example            |
+| Setting                        | Description        |
 | ------------------------------ | ------------------ |
 | `Set Shell "bash"`             | Shell to use       |
 | `Set FontSize 14`              | Font size          |

--- a/modules/home-manager/purpose/development/languages/nix.nix
+++ b/modules/home-manager/purpose/development/languages/nix.nix
@@ -3,10 +3,20 @@
   config,
   pkgs,
   lib,
+  importExternals ? true,
   ...
 }:
+let
+  inherit (lib) optional;
+in
+
 import ./mkLanguage.nix {
-  inherit config pkgs lib;
+  inherit
+    config
+    pkgs
+    lib
+    ;
+
   name = "nix";
 
   lspPackages = [
@@ -21,9 +31,7 @@ import ./mkLanguage.nix {
     pkgs.nixpkgs-review
   ];
 
-  imports = [
-    inputs.nix-index-database.homeModules.default
-  ];
+  imports = optional importExternals inputs.nix-index-database.homeModules.default;
 
   extraConfig = {
     programs.nix-index.enable = true;

--- a/modules/home-manager/user/autorun.nix
+++ b/modules/home-manager/user/autorun.nix
@@ -57,7 +57,9 @@ let
         executablePath = mkOption {
           type = types.str;
           default = lib.getExe config.package;
+          defaultText = lib.literalExpression "lib.getExe config.package";
           example = "${pkgs._1password-gui}/bin/1password";
+
           description = ''
             Path to the executable.
 

--- a/modules/home-manager/user/default.nix
+++ b/modules/home-manager/user/default.nix
@@ -23,7 +23,9 @@ in
     sshSocket = lib.mkOption {
       type = lib.types.str;
       default = "/home/${config.home.username}/.1password/agent.sock";
+      defaultText = lib.literalExpression ''"/home/${config.home.username}/.1password/agent.sock"'';
     };
+
   };
 
   config = {

--- a/modules/home-manager/user/persistence.nix
+++ b/modules/home-manager/user/persistence.nix
@@ -6,8 +6,10 @@
 }:
 with lib;
 let
+  inherit (lib) literalExpression;
   cfg = config.user.persistence;
 in
+
 {
   options.user.persistence = {
     enable = mkEnableOption "persistence";
@@ -19,6 +21,12 @@ in
           "${osConfig.host.persistence.root}/home/${config.home.username}"
         else
           "/persist/home/${config.home.username}";
+      defaultText = literalExpression ''
+        if (osConfig != null) then
+          "''${osConfig.host.persistence.root}/home/''${config.home.username}"
+        else
+          "/persist/home/''${config.home.username}"
+      '';
     };
 
     directories = mkOption {

--- a/modules/nixos/core/activation.nix
+++ b/modules/nixos/core/activation.nix
@@ -5,13 +5,20 @@
   ...
 }:
 let
-  inherit (lib) getExe mkIf mkEnableOption;
+  inherit (lib)
+    getExe
+    literalExpression
+    mkIf
+    mkEnableOption
+    ;
+
   cfg = config.core.activation;
 in
 {
   options.core.activation = {
     enable = mkEnableOption "report diff on activation" // {
       default = config.core.enable;
+      defaultText = literalExpression "config.core.enable";
     };
   };
 

--- a/modules/nixos/core/generators.nix
+++ b/modules/nixos/core/generators.nix
@@ -28,6 +28,7 @@ in
   options.core.generators = {
     enable = mkEnableOption "generators configuration" // {
       default = config.core.enable;
+      defaultText = literalExpression "config.core.enable";
     };
 
     proxmoxLXC = {

--- a/modules/nixos/server/storage/bucket.nix
+++ b/modules/nixos/server/storage/bucket.nix
@@ -397,6 +397,7 @@ in
               credentialsFile = mkOption {
                 type = nullOr str;
                 default = null;
+                example = literalExpression "/run/secrets/s3fs-credentials";
                 description = ''
                   Path to the MinIO credentials file in `ACCESS_KEY_ID:SECRET_ACCESS_KEY` format.
 

--- a/modules/nixos/server/storage/bucket.nix
+++ b/modules/nixos/server/storage/bucket.nix
@@ -397,7 +397,7 @@ in
               credentialsFile = mkOption {
                 type = nullOr str;
                 default = null;
-                example = literalExpression "/run/secrets/s3fs-credentials";
+                example = "/run/secrets/s3fs-credentials";
                 description = ''
                   Path to the MinIO credentials file in `ACCESS_KEY_ID:SECRET_ACCESS_KEY` format.
 

--- a/modules/nixos/server/storage/seaweedfs.nix
+++ b/modules/nixos/server/storage/seaweedfs.nix
@@ -2,6 +2,7 @@
   config,
   inputs,
   lib,
+  importExternals ? true,
   ...
 }:
 let
@@ -16,6 +17,7 @@ let
     flatten
     attrsToList
     optionals
+    optional
     ;
   inherit (config.server) ioPrimaryHost;
 
@@ -136,9 +138,7 @@ let
   ];
 in
 {
-  imports = [
-    inputs.seaweedfs.outPath
-  ];
+  imports = optional importExternals inputs.seaweedfs.outPath;
 
   config = mkIf isIOPrimary {
     # Access to sops certs.

--- a/modules/nixos/services/zeroclaw.nix
+++ b/modules/nixos/services/zeroclaw.nix
@@ -1,0 +1,359 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.zeroclaw;
+  inherit (lib)
+    attrNames
+    concatMapStrings
+    literalExpression
+    mkEnableOption
+    mkIf
+    mkOption
+    mkPackageOption
+    optionalAttrs
+    optionalString
+    types
+    ;
+
+  toml = pkgs.formats.toml { };
+
+  channelsWithSecret = lib.filterAttrs (_: channel: channel.secretFiles != { }) cfg.channels;
+  agentsWithSecret = attrNames (lib.filterAttrs (_: agent: agent.apiKeyFile != null) cfg.agents);
+  nonSecretChannelNames = attrNames (
+    lib.filterAttrs (k: _: !(channelsWithSecret ? ${k})) (cfg.settings.channels_config or { })
+  );
+
+  # Strips channels_config entirely when any channel has secrets to avoid TOML
+  # duplicate-table-header errors. Strips individual agent entries that have an
+  # apiKeyFile. Both sections are re-written by the mergeScript at runtime.
+  filteredSettings =
+    let
+      settingsNoChannelsWithSecret =
+        if channelsWithSecret != { } then
+          lib.filterAttrs (k: _: k != "channels_config") cfg.settings
+        else
+          cfg.settings;
+      agentsWithoutSecret = lib.filterAttrs (
+        k: _: !(builtins.elem k agentsWithSecret)
+      ) settingsNoChannelsWithSecret.agents;
+    in
+    if agentsWithSecret != [ ] && settingsNoChannelsWithSecret ? agents then
+      settingsNoChannelsWithSecret // { agents = agentsWithoutSecret; }
+    else
+      settingsNoChannelsWithSecret;
+
+  configFile = toml.generate "zeroclaw-config.toml" filteredSettings;
+
+  # cli = true belongs to the parent [channels_config] table and must appear
+  # before any [channels_config.*] subtables.
+  channelsConfigHeader = toml.generate "zeroclaw-channels-header.toml" {
+    channels_config.cli = true;
+  };
+
+  channelConfigFile =
+    name:
+    toml.generate "zeroclaw-channel-${name}.toml" {
+      channels_config.${name} = (cfg.settings.channels_config or { }).${name} or { };
+    };
+
+  agentConfigFile =
+    name:
+    toml.generate "zeroclaw-agent-${name}.toml" {
+      agents.${name} = (cfg.settings.agents or { }).${name} or { };
+    };
+
+  mergeScript = pkgs.writeShellScript "zeroclaw-merge-config" ''
+    set -euo pipefail
+    ZEROCLAW_CONFIG="$ZEROCLAW_CONFIG_DIR/config.toml"
+    ${optionalString cfg.mutableConfig ''
+      if [ -f "$ZEROCLAW_CONFIG" ]; then
+        echo "zeroclaw: mutableConfig is enabled and config.toml already exists, skipping update"
+        exit 0
+      fi
+    ''}
+    install -m 0600 ${configFile} "$ZEROCLAW_CONFIG"
+    ${optionalString (channelsWithSecret != { }) ''
+      cat ${channelsConfigHeader} >> "$ZEROCLAW_CONFIG"
+      ${concatMapStrings (channelName: ''
+        cat ${channelConfigFile channelName} >> "$ZEROCLAW_CONFIG"
+      '') nonSecretChannelNames}
+      ${concatMapStrings (channelName: ''
+        cat ${channelConfigFile channelName} >> "$ZEROCLAW_CONFIG"
+        ${concatMapStrings (fieldName: ''
+          printf '${fieldName} = "%s"\n' "$(cat ${
+            lib.escapeShellArg cfg.channels.${channelName}.secretFiles.${fieldName}
+          })" >> "$ZEROCLAW_CONFIG"
+        '') (attrNames cfg.channels.${channelName}.secretFiles)}
+      '') (attrNames channelsWithSecret)}
+    ''}
+    ${concatMapStrings (agentName: ''
+      cat ${agentConfigFile agentName} >> "$ZEROCLAW_CONFIG"
+      printf 'api_key = "%s"\n' "$(cat ${
+        lib.escapeShellArg cfg.agents.${agentName}.apiKeyFile
+      })" >> "$ZEROCLAW_CONFIG"
+    '') agentsWithSecret}
+  '';
+in
+{
+  options.services.zeroclaw = {
+    enable = mkEnableOption "ZeroClaw agent daemon";
+
+    package = mkPackageOption pkgs "zeroclaw" { };
+
+    stateDir = mkOption {
+      type = types.str;
+      default = "zeroclaw";
+      description = ''
+        Relative path under /var/lib for ZeroClaw runtime state.
+        The config.toml is written here at each service start, if mutableConfig is disabled.
+        Use settings and channels.<name>.secretFiles or agents.<name>.apiKeyFile instead.
+      '';
+    };
+
+    host = mkOption {
+      type = types.str;
+      default = "127.0.0.1";
+      description = "Host the gateway binds to.";
+    };
+
+    port = mkOption {
+      type = types.port;
+      default = 42617;
+      description = "Port the gateway listens on.";
+    };
+
+    extraGroups = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [ "users" ];
+      description = ''
+        Additional groups the daemon is member of.
+      '';
+    };
+
+    mutableConfig = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        When false (default), the config.toml is regenerated from module options and
+        settings on every service start.
+
+        When true, config.toml is written only on first start (if it does not
+        already exist). Subsequent starts leave the file untouched, so runtime
+        edits made through the web UI or CLI persist across restarts.
+
+        Switching from false to true takes effect on the next start after the
+        file is first written. To reset to the Nix-managed config, delete
+        /var/lib/''${cfg.stateDir}/config.toml and restart the service.
+      '';
+    };
+
+    settings = mkOption {
+      type = types.attrs;
+      default = { };
+      description = ''
+        Non-secret configuration serialised 1:1 as TOML into config.toml.
+        Keys not set here fall back to Rust-side defaults in the binary.
+
+        This is the primary way to configure the provider, model, memory
+        backend, autonomy policy, heartbeat, observability, and anything
+        else not covered by a dedicated module option.
+
+        Do not place secrets here. The result ends up in the Nix store.
+        Use channels.<name>.secretFiles or agents.<name>.apiKeyFile instead.
+      '';
+      example = literalExpression ''
+        {
+          default_provider = "ollama";
+          default_model = "qwen3-coder-next:q4_K_M";
+          api_url = "http://127.0.0.1:11434";
+          memory.backend = "sqlite";
+          web_fetch = { enabled = true; allowed_domains = [ "*" ]; };
+          web_search.enabled = true;
+          autonomy.auto_approve = [ "file_read" "memory_recall" "web_fetch" "web_search" ];
+          heartbeat = { enabled = true; interval_minutes = 60; };
+          observability.backend = "log";
+        }
+      '';
+    };
+
+    agents = mkOption {
+      type = types.attrsOf (
+        types.submodule {
+          options.apiKeyFile = mkOption {
+            type = types.nullOr types.path;
+            default = null;
+            description = ''
+              Path to a file containing the API key for this agent's provider.
+              If null, the agent uses the top-level api_key or ZEROCLAW_API_KEY.
+
+              Non-secret agent settings (provider, model, agentic, allowed_tools,
+              system_prompt, etc.) belong in settings.agents.<name>.
+            '';
+            example = "/run/secrets/anthropic-api-key";
+          };
+        }
+      );
+      default = { };
+      description = ''
+        Per-agent runtime secrets. Keys are agent names matching
+        settings.agents.<name>. Only the API key goes here. All other
+        agent settings belong in settings.agents.<name>.
+      '';
+      example = literalExpression ''
+        {
+          researcher.apiKeyFile = config.sops.secrets.anthropic-api-key.path;
+          coder.apiKeyFile = "/run/secrets/ollama-api-key";
+        }
+      '';
+    };
+
+    environmentFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      description = ''
+        Path to a file of environment variables injected into the daemon.
+        Useful for secrets that have environment-variable overrides, most
+        notably ZEROCLAW_API_KEY (the main provider API key). Channel
+        tokens have no env-var overrides: use channels.<name>.secretFiles.
+
+        Example file contents:
+          ZEROCLAW_API_KEY=sk-ant-...
+      '';
+    };
+
+    channels = mkOption {
+      type = types.attrsOf (
+        types.submodule {
+          options.secretFiles = mkOption {
+            type = types.attrsOf types.path;
+            default = { };
+            description = ''
+              Map of TOML field name → path to a file containing that secret value.
+              Read at service start; never written to the Nix store.
+              Having at least one entry here enables the channel.
+
+              Field names must match the zeroclaw config keys exactly (e.g.
+              bot_token, app_token, access_token). Works with any secrets
+              manager (sops-nix, agenix, plain files, ...).
+
+              Non-secret channel settings (allowed_users, stream_mode, etc.)
+              belong in settings.channels_config.<name>.
+            '';
+            example = literalExpression ''
+              { bot_token = "/run/secrets/telegram-bot-token"; }
+            '';
+          };
+        }
+      );
+      default = { };
+      description = ''
+        Per-channel runtime secrets. Keys are channel names as recognised by
+        zeroclaw (telegram, discord, slack, mattermost, matrix, ...).
+
+        Each channel's secretFiles maps TOML field names to secret file paths.
+        Non-secret settings belong in settings.channels_config.<name>.
+
+        Channels with no secrets (e.g. signal, cli) need no entry here:
+        configure them entirely via settings.channels_config.<name>.
+      '';
+      example = literalExpression ''
+        {
+          telegram.secretFiles.bot_token = config.sops.secrets.telegram-bot-token.path;
+          slack.secretFiles = {
+            bot_token = config.sops.secrets.slack-not-token.path;
+            app_token = config.sops.secrets.slack-app-token.path;
+          };
+          matrix.secretFiles.access_token = "/run/secrets/matrix-access-token";
+        }
+      '';
+    };
+
+    web.nginx.virtualHost = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "zeroclaw.example.com";
+      description = ''
+        Hostname of the nginx virtualHost to proxy to the zeroclaw daemon.
+
+        This module only adds a `location /` proxy block to the named
+        virtualHost. You must declare the virtualHost separately to control
+        SSL, ACME, listen addresses, and access rules. E.g. to enable TLS:
+
+        services.nginx.virtualHosts."zeroclaw.example.com" = {
+          forceSSL = true;
+          enableACME = true;
+        };
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.zeroclaw = {
+      description = "ZeroClaw Agent Daemon";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      restartTriggers = [ configFile ];
+
+      environment = {
+        ZEROCLAW_CONFIG_DIR = "/var/lib/${cfg.stateDir}";
+        ZEROCLAW_WORKSPACE = "/var/lib/${cfg.stateDir}/workspace";
+        ZEROCLAW_GATEWAY_HOST = cfg.host;
+        ZEROCLAW_GATEWAY_PORT = toString cfg.port;
+      }
+      # allow_public_bind is required when binding to a non-loopback address
+      // optionalAttrs (cfg.host != "127.0.0.1" && cfg.host != "localhost" && cfg.host != "::1") {
+        ZEROCLAW_ALLOW_PUBLIC_BIND = "1";
+      };
+
+      serviceConfig = {
+        Type = "exec";
+        DynamicUser = true;
+        SupplementaryGroups = cfg.extraGroups;
+        StateDirectory = [
+          cfg.stateDir
+          "${cfg.stateDir}/workspace"
+        ];
+        WorkingDirectory = "%S/${cfg.stateDir}";
+
+        ExecStartPre = "${mergeScript}";
+        ExecStart = "${lib.getExe cfg.package} daemon";
+
+        EnvironmentFile = lib.mkIf (cfg.environmentFile != null) cfg.environmentFile;
+
+        # Hardening
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        CapabilityBoundingSet = "";
+        LockPersonality = true;
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+
+        Restart = "on-failure";
+        RestartSec = "5s";
+      };
+    };
+
+    services.nginx.virtualHosts = mkIf (cfg.web.nginx.virtualHost != null) {
+      ${cfg.web.nginx.virtualHost} = {
+        locations."/" = {
+          proxyPass = "http://${cfg.host}:${toString cfg.port}";
+          proxyWebsockets = true;
+          extraConfig = ''
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+          '';
+        };
+      };
+    };
+  };
+}

--- a/pkgs/drive-stats/default.nix
+++ b/pkgs/drive-stats/default.nix
@@ -16,4 +16,6 @@ writeShellApplication {
     util-linux
     zfs
   ];
+
+  passthru.discovery = false;
 }

--- a/pkgs/helpers/new-host.nix
+++ b/pkgs/helpers/new-host.nix
@@ -16,4 +16,6 @@ writeShellApplication {
     ssh-to-age
     findutils
   ];
+
+  passthru.discovery = false;
 }

--- a/pkgs/list-ephemeral/default.nix
+++ b/pkgs/list-ephemeral/default.nix
@@ -21,6 +21,8 @@ writeShellApplication {
 
   text = builtins.readFile ./list-ephemeral.sh;
 
+  passthru.discovery = false;
+
   meta = {
     description = "List ephemeral paths that will be lost when restarting the system";
     longDescription = ''


### PR DESCRIPTION
docs: Convert options to generated options

fix(docs): stop docs build recursion

fix(docs): README substitution

refactor(docs): auto-discover modules for option generation

refactor(docs): lots of cleanup, fixes & changes

fix(docs): validate mdbook include targets

refactor(docs): some bullshit

generate option fragments for default modules

Handle module prefixes that come from default.nix entrypoints and nested options JSON so generated mdbook fragments are not empty.

restore mdbook preprocessors and option fragments

Debug default.nix option fragment generation, mdbook preprocessor wiring, and generated include paths across docs pages.

generate flake module option fragments

Enable docs discovery and generated option fragments for modules/flake pages.

repair code link rewriting and gaming option fragments

Fix rewrite-code-links matching and ensure gaming docs include default module options.

docs: fix links ditch unrequired extra preprocessors

docs: fix preprocessor issues and GNOME dconf links

chore: remove package

fix(docs): inline zeroclaw module to avoid bare store path declaration

The ixx tool (used by NuschtOS/search) requires option declarations to be store paths with at least 4 slashes (i.e., /nix/store/hash-name/subpath). The services-zeroclaw file-type flake input produces a bare store path (/nix/store/hash-source) with no subpath, causing ixx to fail.

Fix by copying the zeroclaw.nix module into the repo and importing it locally, so its declarations resolve through self with proper subpaths.